### PR TITLE
Fix several quirks based on Metals PR

### DIFF
--- a/munit/src/main/scala/munit/Diff.scala
+++ b/munit/src/main/scala/munit/Diff.scala
@@ -3,7 +3,7 @@ package munit
 import com.geirsson.junit.Ansi
 import collection.JavaConverters._
 
-class Diff(val obtained: String, val expected: String) {
+class Diff(val obtained: String, val expected: String) extends Serializable {
   val obtainedClean = Ansi.filterAnsi(obtained)
   val expectedClean = Ansi.filterAnsi(expected)
   val obtainedLines = splitIntoLines(obtainedClean)

--- a/munit/src/main/scala/munit/FailException.scala
+++ b/munit/src/main/scala/munit/FailException.scala
@@ -1,4 +1,23 @@
 package munit
 
-class FailException(message: String, location: Location)
-    extends Exception(message)
+class FailException(
+    message: String,
+    cause: Throwable,
+    isStackTracesEnabled: Boolean,
+    location: Location
+) extends Exception(message, cause)
+    with Serializable {
+  def this(message: String, location: Location) =
+    this(message, null, true, location)
+  def this(message: String, cause: Throwable, location: Location) = this(
+    message,
+    cause,
+    true,
+    location
+  )
+  override def fillInStackTrace(): Throwable = {
+    val result = super.fillInStackTrace()
+    result.setStackTrace(result.getStackTrace().slice(0, 1))
+    result
+  }
+}

--- a/munit/src/main/scala/munit/GenericBeforeEach.scala
+++ b/munit/src/main/scala/munit/GenericBeforeEach.scala
@@ -2,8 +2,8 @@ package munit
 
 class GenericBeforeEach[T](
     val test: GenericTest[T]
-)
+) extends Serializable
 
 class GenericAfterEach[T](
     val test: GenericTest[T]
-)
+) extends Serializable

--- a/munit/src/main/scala/munit/GenericTest.scala
+++ b/munit/src/main/scala/munit/GenericTest.scala
@@ -14,7 +14,7 @@ class GenericTest[T](
     val body: () => T,
     val tags: Set[Tag],
     val location: Location
-) {
+) extends Serializable {
   def withName(newName: String): GenericTest[T] =
     copy(name = newName)
   def withBody[A](newBody: () => A): GenericTest[A] =

--- a/munit/src/main/scala/munit/Lines.scala
+++ b/munit/src/main/scala/munit/Lines.scala
@@ -7,7 +7,7 @@ import java.nio.file.Files
 import scala.util.control.NonFatal
 import scala.collection.JavaConverters._
 
-class Lines {
+class Lines extends Serializable {
   private val filecache = mutable.Map.empty[Path, Array[String]]
 
   def formatLine(location: Location, message: String): String = {

--- a/munit/src/main/scala/munit/Tag.scala
+++ b/munit/src/main/scala/munit/Tag.scala
@@ -3,7 +3,7 @@ package munit
 import java.lang.annotation.Annotation
 import scala.runtime.Statics
 
-class Tag(val value: String) extends Annotation {
+class Tag(val value: String) extends Annotation with Serializable {
   // Not a case class so that it possible to override these.
   override def equals(obj: Any): Boolean = obj match {
     case t: Tag => t.value == value

--- a/munit/src/main/scala/munit/TestOptions.scala
+++ b/munit/src/main/scala/munit/TestOptions.scala
@@ -7,12 +7,23 @@ package munit
   * @param name the test name, used in the UI and to select it with testOnly
   * @param tags a set of [[tests.Tag]], used to attach semantic information to a test
   */
-case class TestOptions(name: String, tags: Set[Tag], loc: Location) {
+final class TestOptions(
+    val name: String,
+    val tags: Set[Tag],
+    val loc: Location
+) extends Serializable {
   def fail: TestOptions = tag(Fail)
   def flaky: TestOptions = tag(Flaky)
   def ignore: TestOptions = tag(Ignore)
   def only: TestOptions = tag(Only)
   def tag(t: Tag): TestOptions = copy(tags = tags + t)
+  private[this] def copy(
+      name: String = this.name,
+      tags: Set[Tag] = this.tags,
+      loc: Location = this.loc
+  ): TestOptions = {
+    new TestOptions(name, tags, loc)
+  }
 }
 
 trait TestOptionsConversions {
@@ -24,5 +35,5 @@ trait TestOptionsConversions {
   implicit def testOptionsFromString(
       name: String
   )(implicit loc: Location): TestOptions =
-    TestOptions(name, Set.empty, loc)
+    new TestOptions(name, Set.empty, loc)
 }

--- a/munit/src/main/scala/munit/TestValues.scala
+++ b/munit/src/main/scala/munit/TestValues.scala
@@ -9,8 +9,13 @@ object TestValues {
 
   /** The test failed with the given exception but was ignored but its marked as flaky */
   class FlakyFailure(error: Throwable)
-      extends Exception("ignoring flaky test failure", error)
+      extends FailException(
+        "ignoring flaky test failure",
+        error,
+        Location.empty
+      )
       with NoStackTrace
+      with Serializable
 
   /** The test case was ignored. */
   val Ignore = munit.Ignore

--- a/tests/src/main/scala/munit/CiOnlyFrameworkSuite.scala
+++ b/tests/src/main/scala/munit/CiOnlyFrameworkSuite.scala
@@ -9,3 +9,13 @@ class CiOnlyFrameworkSuite extends FunSuite {
     ???
   }
 }
+
+object CiOnlyFrameworkSuite
+    extends FrameworkTest(
+      classOf[CiOnlyFrameworkSuite],
+      """|==> failure munit.CiOnlyFrameworkSuite.only - /scala/munit/CiOnlyFrameworkSuite.scala:5 'Only' tag is not allowed when `isCI=true`
+         |4:   override def isCI: Boolean = true
+         |5:   test("only".only) {
+         |6:     println("pass")
+       """.stripMargin
+    )

--- a/tests/src/main/scala/munit/DiffProductFrameworkSuite.scala
+++ b/tests/src/main/scala/munit/DiffProductFrameworkSuite.scala
@@ -12,3 +12,28 @@ class DiffProductFrameworkSuite extends FunSuite {
   }
 
 }
+
+object DiffProductFrameworkSuite
+    extends FrameworkTest(
+      classOf[DiffProductFrameworkSuite],
+      """|==> failure munit.DiffProductFrameworkSuite.pass - /scala/munit/DiffProductFrameworkSuite.scala:11 values are not the same
+         |=> Obtained
+         |User(
+         |  name = "John",
+         |  age = 43,
+         |  friends = List(
+         |    2
+         |  )
+         |)
+         |=> Diff (- obtained, + expected)
+         |   name = "John",
+         |-  age = 43,
+         |+  age = 42,
+         |   friends = List(
+         |+    1,
+         |     2
+         |10:     val john2 = User("John", 43, 2.to(2).toList)
+         |11:     assertEqual(john2, john)
+         |12:   }
+         |""".stripMargin
+    )

--- a/tests/src/main/scala/munit/DuplicateNameFrameworkSuite.scala
+++ b/tests/src/main/scala/munit/DuplicateNameFrameworkSuite.scala
@@ -8,3 +8,11 @@ class DuplicateNameFrameworkSuite extends FunSuite {
     // pass
   }
 }
+
+object DuplicateNameFrameworkSuite
+    extends FrameworkTest(
+      classOf[DuplicateNameFrameworkSuite],
+      """|==> success munit.DuplicateNameFrameworkSuite.basic
+         |==> success munit.DuplicateNameFrameworkSuite.basic-1
+         |""".stripMargin
+    )

--- a/tests/src/main/scala/munit/FailFrameworkSuite.scala
+++ b/tests/src/main/scala/munit/FailFrameworkSuite.scala
@@ -8,3 +8,14 @@ class FailFrameworkSuite extends FunSuite {
     ???
   }
 }
+
+object FailFrameworkSuite
+    extends FrameworkTest(
+      classOf[FailFrameworkSuite],
+      """|==> failure munit.FailFrameworkSuite.pass - /scala/munit/FailFrameworkSuite.scala:4 expected failure but test passed
+         |3: class FailFrameworkSuite extends FunSuite {
+         |4:   test("pass".fail) {
+         |5:     // println("pass")
+         |==> success munit.FailFrameworkSuite.fail
+         |""".stripMargin
+    )

--- a/tests/src/main/scala/munit/FrameworkTest.scala
+++ b/tests/src/main/scala/munit/FrameworkTest.scala
@@ -1,0 +1,7 @@
+package munit
+
+// Framework tests needs to be manually added to FrameworkSuite.tests
+class FrameworkTest(
+    val cls: Class[_ <: FunSuite],
+    val expected: String
+)(implicit val location: Location)

--- a/tests/src/main/scala/munit/InterceptFrameworkSuite.scala
+++ b/tests/src/main/scala/munit/InterceptFrameworkSuite.scala
@@ -1,0 +1,19 @@
+package munit
+
+class InterceptFrameworkSuite extends FunSuite {
+  test("not-implemented") {
+    intercept[NotImplementedError](???)
+  }
+  class FooException extends Exception("Foo")
+  test("type-mismatch") {
+    intercept[FooException](???)
+  }
+}
+
+object InterceptFrameworkSuite
+    extends FrameworkTest(
+      classOf[InterceptFrameworkSuite],
+      """|==> success munit.InterceptFrameworkSuite.not-implemented
+         |==> failure munit.InterceptFrameworkSuite.type-mismatch - intercept failed, exception 'scala.NotImplementedError' is not a subtype of 'munit.InterceptFrameworkSuite.FooException
+         |""".stripMargin
+    )

--- a/tests/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/src/test/scala/munit/FrameworkSuite.scala
@@ -12,53 +12,14 @@ import sbt.testing.Status
 import scala.util.Properties
 
 class FrameworkSuite extends BaseFrameworkSuite {
-  check(
-    classOf[CiOnlyFrameworkSuite],
-    """|==> failure munit.CiOnlyFrameworkSuite.only - /scala/munit/CiOnlyFrameworkSuite.scala:5 'Only' tag is not allowed when `isCI=true`
-       |4:   override def isCI: Boolean = true
-       |5:   test("only".only) {
-       |6:     println("pass")
-       |""".stripMargin
+  val tests = List[FrameworkTest](
+    InterceptFrameworkSuite,
+    CiOnlyFrameworkSuite,
+    DiffProductFrameworkSuite,
+    FailFrameworkSuite,
+    DuplicateNameFrameworkSuite
   )
-
-  check(
-    classOf[DiffProductFrameworkSuite],
-    """|==> failure munit.DiffProductFrameworkSuite.pass - /scala/munit/DiffProductFrameworkSuite.scala:11 values are not the same
-       |=> Obtained
-       |User(
-       |  name = "John",
-       |  age = 43,
-       |  friends = List(
-       |    2
-       |  )
-       |)
-       |=> Diff (- obtained, + expected)
-       |   name = "John",
-       |-  age = 43,
-       |+  age = 42,
-       |   friends = List(
-       |+    1,
-       |     2
-       |10:     val john2 = User("John", 43, 2.to(2).toList)
-       |11:     assertEqual(john2, john)
-       |12:   }
-       |""".stripMargin
-  )
-
-  check(
-    classOf[FailFrameworkSuite],
-    """|==> failure munit.FailFrameworkSuite.pass - /scala/munit/FailFrameworkSuite.scala:4 expected failure but test passed
-       |3: class FailFrameworkSuite extends FunSuite {
-       |4:   test("pass".fail) {
-       |5:     // println("pass")
-       |==> success munit.FailFrameworkSuite.fail
-       |""".stripMargin
-  )
-
-  check(
-    classOf[DuplicateNameFrameworkSuite],
-    """|==> success munit.DuplicateNameFrameworkSuite.basic
-       |==> success munit.DuplicateNameFrameworkSuite.basic-1
-       |""".stripMargin
-  )
+  tests.foreach { t =>
+    check(t.cls, t.expected)(t.location)
+  }
 }


### PR DESCRIPTION
* Add missing `intercept` assertion
* Improve framework testing infrastructure
* Add serializable trait where relevant, exceptions may be
  serialized by sbt.
* Don't use case class for TestOptions
* Make FlakyFailure extend FailException
* Make FailException support suppressing the stack trace