### PR TITLE
Add basic test cases for Lines class.

### DIFF
--- a/munit/shared/src/main/scala-0.21/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-0.21/munit/internal/MacroCompat.scala
@@ -6,13 +6,13 @@ import scala.quoted._
 object MacroCompat {
 
   trait LocationMacro {
-    inline implicit def generateLocation: Location = ${ locationImpl() }
+    inline implicit def generate: Location = ${ locationImpl() }
   }
 
   def locationImpl()(given qctx: QuoteContext): Expr[Location] = {
     import qctx.tasty.{_, given}
     val path = rootPosition.sourceFile.jpath.toString
-    val startLine = rootPosition.startLine
+    val startLine = rootPosition.startLine + 1
     '{ new Location(${Expr(path)}, ${Expr(startLine)}) }
   }
 

--- a/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
@@ -7,7 +7,7 @@ import scala.reflect.macros.blackbox.Context
 object MacroCompat {
 
   trait LocationMacro {
-    implicit def generateLocation: Location = macro locationImpl
+    implicit def generate: Location = macro locationImpl
   }
 
   def locationImpl(c: Context): c.Tree = {

--- a/munit/shared/src/main/scala/munit/internal/console/Lines.scala
+++ b/munit/shared/src/main/scala/munit/internal/console/Lines.scala
@@ -26,12 +26,15 @@ class Lines extends Serializable {
           val padding = " " * (width - number.length() + 1)
           number + padding
         }
+        val isMultilineMessage = message.contains('\n')
         out
           .append(location.path)
           .append(':')
           .append(location.line.toString())
-          .append(if (message.length == 0) "" else " ")
-          .append(message)
+        if (message.length() > 0 && !isMultilineMessage) {
+          out.append(" ").append(message)
+        }
+        out
           .append('\n')
           .append(format(location.line - 1))
           .append(slice(0))
@@ -43,6 +46,9 @@ class Lines extends Serializable {
           .append('\n')
           .append(format(location.line + 1))
           .append(slice(2))
+        if (isMultilineMessage) {
+          out.append('\n').append(message)
+        }
       }
       out.toString()
     } catch {

--- a/tests/shared/src/main/scala/munit/DiffProductFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/DiffProductFrameworkSuite.scala
@@ -14,7 +14,11 @@ class DiffProductFrameworkSuite extends FunSuite {
 object DiffProductFrameworkSuite
     extends FrameworkTest(
       classOf[DiffProductFrameworkSuite],
-      """|==> failure munit.DiffProductFrameworkSuite.pass - /scala/munit/DiffProductFrameworkSuite.scala:9 values are not the same
+      """|==> failure munit.DiffProductFrameworkSuite.pass - /scala/munit/DiffProductFrameworkSuite.scala:9
+         |8:     val john2 = User("John", 43, 2.to(2).toList)
+         |9:     assertEqual(john2, john)
+         |10:  }
+         |values are not the same
          |=> Obtained
          |User(
          |  name = "John",
@@ -30,8 +34,5 @@ object DiffProductFrameworkSuite
          |   friends = List(
          |+    1,
          |     2
-         |8:     val john2 = User("John", 43, 2.to(2).toList)
-         |9:     assertEqual(john2, john)
-         |10:  }
          |""".stripMargin
     )

--- a/tests/shared/src/test/scala/munit/LinesSuite.scala
+++ b/tests/shared/src/test/scala/munit/LinesSuite.scala
@@ -1,0 +1,46 @@
+package munit
+
+class LinesSuite extends FunSuite {
+
+  check(
+    "basic",
+    "hello",
+    Location.generate,
+    // comment
+    """|LinesSuite.scala:8 hello
+       |7:    "hello",
+       |8:    Location.generate,
+       |9:    // comment
+       |""".stripMargin
+  )
+
+  check(
+    "multiline",
+    "hello\nworld!",
+    Location.generate,
+    // comment
+    """|LinesSuite.scala:20
+       |19:    "hello\nworld!",
+       |20:    Location.generate,
+       |21:    // comment
+       |hello
+       |world!
+       |""".stripMargin
+  )
+
+  // This method is written at the bottom of the file to keep stable line
+  // numbers in the test cases above.
+  def check(
+      name: String,
+      message: String,
+      location: Location,
+      expected: String
+  )(implicit loc: Location): Unit = {
+    test(name) {
+      val obtained = munitLines
+        .formatLine(location, message)
+        .replaceAllLiterally(location.path, location.filename)
+      assertNoDiff(obtained, expected)
+    }
+  }
+}


### PR DESCRIPTION
The way it formatted multiline messages made it hard to read before.
Now, if the message is multiline we put the message after the formatted
source code in order to ensure the `/filename:line` line always appears
in the line above the formatted source.