### PR TITLE
Add `mdoc:munit` modifier to render test reports on the website.

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,7 @@
+-Xss4m
+-Xms1G
+-Xmx2G
+-XX:ReservedCodeCacheSize=1024m
+-XX:+TieredCompilation
+-XX:+CMSClassUnloadingEnabled
+-Dfile.encoding=UTF-8

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -1,0 +1,105 @@
+---
+id: reports
+title: Generating test reports
+---
+
+The MUnit sbt plugin supports collecting historical data about your test reports
+and displaying HTML report summaries about your test suites. The test report
+data is stored in Google Cloud Storage and the HTML report is rendered with an
+[MDoc markdown modifier](https://scalameta.org/mdoc/docs/modifiers.html).
+
+## Example
+
+Below is the generated report from the tests in the MUnit codebase.
+
+```scala mdoc:munit
+
+```
+
+## Installation
+
+> These installation instructions are experimental and subject to change.
+
+First, install the sbt-munit plugin.
+
+```scala
+// project/plugins.sbt
+addSbtPlugin("org.scalameta" % "sbt-munit" % "@VERSION@")
+```
+
+Next, setup up
+[Google Cloud authentication credentials](https://console.cloud.google.com/apis/credentials/serviceaccountkey).
+You should have a JSON file that looks like this.
+
+```json
+{
+  "type": "service_account",
+  "project_id": "...",
+  "private_key": "---BEGIN PRIVATE KEY---...."
+  // ...
+}
+```
+
+Next, add the following two secret environment variables to your CI settings.
+
+- `GOOGLE_APPLICATION_CREDENTIALS_JSON`: the base64 encoded value of the JSON
+  file containing the credentials.
+
+```sh
+export GCP_CREDENTIALS="/path/to/json/file/on/your/computer"
+# macOS
+cat $GCP_CREDENTIALS | base64 | pbcopy
+# Ubuntu (assuming GNU base64)
+cat $GCP_CREDENTIALS | base64 -w0 | xclip
+# Arch
+cat $GCP_CREDENTIALS | base64 | sed -z 's;\n;;g' | xclip -selection clipboard -i
+# FreeBSD (assuming BSD base64)
+cat $GCP_CREDENTIALS | base64 | xclip
+```
+
+- `GOOGLE_APPLICATION_CREDENTIALS`: an arbitrary relative filename like
+  `"gcp.json"`. This should **not** match the path on your personal computer.
+  The exact value of this variable doesn't matter as long as the file path is
+  relative and the file does not exists in your repository. The MUnit sbt plugin
+  will generate this file from the base64 secret variable.
+
+> Verify that your CI provider only exposes secret environment variables to the
+> jobs that run on master branch and not pull requests.
+
+If you use GitHub actions, open the following URL for your repository
+https://github.com/scalameta/munit/settings/secrets to configure secret
+environment variables. Once the secrets are correctly configured, the page
+should looks something like this:
+
+![Example screenshot from GitHub Actions secrets page](https://i.imgur.com/Zdvc7cc.png)
+
+Merge some changes into master and verify that the test reports are getting
+uploaded to Google Cloud.
+
+```sh
+❯ gsutil ls -r 'gs://munit-test-reports/**'
+gs://munit-test-reports/scalameta/munit/2020-01-26/refs/heads/master/670f475b49a44a87d515ec48b9749ec196336f78/testsJVM/0.21.0-RC1/1.8.0_232.json
+...
+```
+
+Next, [setup MDoc](https://scalameta.org/mdoc/docs/installation.html) to
+generate documentation. Once you have MDoc setup, enable `MUnitReportPlugin` in
+the same project where `MdocPlugin` is enabled.
+
+```diff
+  // build.sbt
+  lazy val docs = project
+    .in(file("myproject-docs"))
+-   .enablePlugins(MdocPlugin)
++   .enablePlugins(MdocPlugin, MUnitReportPlugin)
+    .settings(...)
+```
+
+Next, you should be able to use the `mdoc:munit` modifier to generate test
+reports from the stored data in Google Cloud.
+
+````md
+```scala mdoc:munit
+
+```
+````

--- a/munit-docs/src/main/java/munit/docs/StorageProxy.java
+++ b/munit-docs/src/main/java/munit/docs/StorageProxy.java
@@ -1,0 +1,12 @@
+package munit.docs;
+
+import java.util.*;
+import com.google.cloud.storage.*;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.api.gax.paging.Page;
+
+public class StorageProxy {
+  public static Page<Blob> list(Storage storage, String bucketName, String prefix) {
+    return storage.list(bucketName, BlobListOption.pageSize(1000), BlobListOption.prefix(prefix));
+  }
+}

--- a/munit-docs/src/main/resources/META-INF/services/mdoc.PreModifier
+++ b/munit-docs/src/main/resources/META-INF/services/mdoc.PreModifier
@@ -1,0 +1,1 @@
+docs.MUnitModifier

--- a/munit-docs/src/main/scala/docs/MUnitModifier.scala
+++ b/munit-docs/src/main/scala/docs/MUnitModifier.scala
@@ -1,0 +1,194 @@
+package docs
+
+import munit.docs.StorageProxy
+import mdoc.PreModifier
+import mdoc.PreModifierContext
+import scala.util.control.NonFatal
+import java.{util => ju}
+import com.google.cloud.storage.StorageOptions
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+import com.google.cloud.storage.Blob
+import java.io.ByteArrayOutputStream
+import munit.sbtmunit.MUnitTestReport
+import com.google.gson.Gson
+import java.nio.charset.StandardCharsets
+import munit.sbtmunit.MUnitTestReport
+import sbt.testing.Status
+import munit.TestValues.FlakyFailure
+
+class MUnitModifier extends PreModifier {
+  val name: String = "munit"
+  def process(ctx: PreModifierContext): String = {
+    html.getOrElse {
+      ctx.reporter.warning("Unable to generate MUnit HTML test report.")
+      ""
+    }
+  }
+
+  private val properties: Map[String, String] =
+    try {
+      val props = new ju.Properties()
+      props.load(
+        this
+          .getClass()
+          .getClassLoader()
+          .getResourceAsStream("munit.properties")
+      )
+      val m = mutable.Map.empty[String, String]
+      props.forEach((k, v) => m(k.toString()) = v.toString())
+      m.toMap
+    } catch {
+      case NonFatal(e) =>
+        e.printStackTrace()
+        Map.empty
+    }
+  lazy val html: Option[String] =
+    try {
+      for {
+        bucketName <- properties.get("munitBucketName")
+        repository <- properties.get("munitRepository")
+      } yield {
+        val storage = StorageOptions.getDefaultInstance().getService()
+        val blobs = StorageProxy
+          .list(storage, bucketName, repository)
+          .iterateAll()
+          .asScala
+        renderHtml(blobs)
+      }
+    } catch {
+      case NonFatal(e) =>
+        e.printStackTrace()
+        None
+    }
+
+  private def downloadBlob(blob: Blob): Option[MUnitTestReport.Summary] = {
+    try {
+      val out = new ByteArrayOutputStream()
+      blob.downloadTo(out)
+      val summary = new Gson().fromJson(
+        new String(out.toByteArray(), StandardCharsets.UTF_8),
+        classOf[MUnitTestReport.Summary]
+      )
+      Some(summary)
+    } catch {
+      case NonFatal(e) =>
+        e.printStackTrace()
+        None
+    }
+  }
+
+  private def renderHtml(blobs: Iterable[Blob]): String = {
+    val tests =
+      mutable.Map.empty[String, mutable.ArrayBuffer[MUnitTestReport.TestEvent]]
+    for {
+      blob <- blobs.iterator
+      summary <- downloadBlob(blob).iterator
+      group <- summary.groups.iterator
+      event <- group.events.toIterable
+    } {
+      val buffer =
+        tests.getOrElseUpdate(event.name, mutable.ArrayBuffer.empty)
+      buffer += event
+    }
+    val statuses = Array(
+      Status.Success,
+      Status.Failure,
+      Status.Skipped,
+      Status.Ignored
+    )
+    val statusHeaders = statuses.map(s => <th>{s}</th>)
+    val keys = tests.keys.toIndexedSeq.sorted
+    val testRows = keys.map { name =>
+      val events = tests(name)
+      val statusMap = events.groupBy(_.status).mapValues(_.size)
+      val passedCount = statusMap.getOrElse(Status.Success.toString(), 0)
+      val errorCount = statusMap.getOrElse(Status.Failure.toString(), 0)
+      val flakyCount = events.count { event =>
+        event.exception != null &&
+        Status.Skipped.toString == event.status &&
+        classOf[FlakyFailure].getName() == event.exception.className
+      }
+      val skippedCount = statusMap.getOrElse(Status.Skipped.toString(), 0) - flakyCount
+      val ignoredCount = statusMap.getOrElse(Status.Ignored.toString(), 0)
+      val statusColumns = statuses.map { s =>
+        statusMap.getOrElse(s.toString(), 0)
+      }
+      val otherCount = events.length -
+        passedCount -
+        errorCount -
+        flakyCount -
+        skippedCount -
+        ignoredCount
+      val flakyRatio: Double =
+        if (passedCount == 0) 0
+        else {
+          val r = flakyCount.toDouble / passedCount.toDouble
+          if (r == 0) 0
+          else r
+        }
+      val totalCount = events.length
+      val averageDuration =
+        if (totalCount == 0) 0
+        else events.iterator.map(_.duration).filter(_ >= 0).sum / totalCount
+      val shortName =
+        if (name.length() > 80) name.take(80) + "..."
+        else name
+      <tr>
+        <td title={name}>{shortName}</td>
+        <td>{averageDuration}</td>
+        <td>{passedCount}</td>
+        <td>{errorCount}</td>
+        <td>{flakyCount}</td>
+        <td>{flakyRatio}</td>
+        <td>{skippedCount}</td>
+        <td>{ignoredCount}</td>
+        <td>{otherCount}</td>
+      </tr>
+    }
+    val table =
+      <table id="munit" class="display">
+      <col width="300"/>
+      <thead>
+      <tr>
+      <th>Name</th>
+      <th>D</th>
+      <th>P</th>
+      <th>E</th>
+      <th>F</th>
+      <th>R</th>
+      <th>S</th>
+      <th>I</th>
+      <th>O</th>
+      </tr>
+      </thead>
+      <tbody>
+        {testRows}
+      </tbody>
+    </table>
+    s"""
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.css">
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.js"></script>
+
+**D**: Average duration in milliseconds, 
+**P**: Passed, 
+**E**: Failed, 
+**F**: Flaky,
+**R**: Flaky/Passed ratio,
+**S**: Skipped, 
+**I**: Ignored, 
+**O**: Other
+
+$table
+
+<script>
+  $$(document).ready( function () {
+    $$('#munit').DataTable({
+      paging: false,
+    });
+  });
+</script>
+"""
+  }
+}

--- a/munit-sbt/src/main/scala/munit/sbtmunit/MUnitGcpListener.scala
+++ b/munit-sbt/src/main/scala/munit/sbtmunit/MUnitGcpListener.scala
@@ -1,4 +1,4 @@
-package munit
+package munit.sbtmunit
 
 import com.google.cloud.storage.StorageOptions
 import com.google.cloud.storage.BucketInfo
@@ -8,11 +8,11 @@ import com.google.cloud.storage.Bucket.BlobTargetOption
 import com.google.cloud.storage.Storage.PredefinedAcl
 import com.google.cloud.storage.StorageException
 import sbt.util.Logger
-import munit.MUnitTestReport.Summary
+import munit.sbtmunit.MUnitTestReport.Summary
 
 class MUnitGcpListener(
     val reportName: String,
-    val bucketName: String = "munit-test-reports",
+    val bucketName: String,
     val maxRetries: Int = 100,
     logger: Logger = sbt.ConsoleLogger()
 ) extends MUnitReportListener {

--- a/munit-sbt/src/main/scala/munit/sbtmunit/MUnitLocalListener.scala
+++ b/munit-sbt/src/main/scala/munit/sbtmunit/MUnitLocalListener.scala
@@ -1,8 +1,7 @@
-package munit
+package munit.sbtmunit
 
 import java.nio.file.Path
 import java.nio.file.Paths
-import munit.MUnitTestReport.Summary
 import sbt.util.Logger
 import com.google.gson.Gson
 import java.nio.charset.StandardCharsets
@@ -15,7 +14,7 @@ class MUnitLocalListener(
     maxRetries: Int = 100,
     logger: Logger = sbt.ConsoleLogger()
 ) extends MUnitReportListener {
-  def onReport(report: Summary): Unit = {
+  def onReport(report: MUnitTestReport.Summary): Unit = {
     val bytes = new Gson().toJson(report).getBytes(StandardCharsets.UTF_8)
     Files.write(
       path,

--- a/munit-sbt/src/main/scala/munit/sbtmunit/MUnitReportListener.scala
+++ b/munit-sbt/src/main/scala/munit/sbtmunit/MUnitReportListener.scala
@@ -1,6 +1,6 @@
-package munit
+package munit.sbtmunit
 
-import munit.MUnitTestReport.Summary
+import munit.sbtmunit.MUnitTestReport.Summary
 
 trait MUnitReportListener {
   def onReport(report: Summary): Unit

--- a/munit-sbt/src/main/scala/munit/sbtmunit/MUnitReportPlugin.scala
+++ b/munit-sbt/src/main/scala/munit/sbtmunit/MUnitReportPlugin.scala
@@ -1,0 +1,28 @@
+package munit.sbtmunit
+
+import sbt._
+import sbt.Keys._
+import MUnitPlugin.autoImport._
+
+object MUnitReportPlugin extends AutoPlugin {
+  override def requires = MUnitPlugin
+  override val projectSettings = List(
+    libraryDependencies ++= {
+      if ("unknown" == BuildInfo.munitVersion) Nil
+      else List("org.scalameta" %% "munit-docs" % BuildInfo.munitVersion)
+    },
+    resourceGenerators.in(Compile) += Def.task[List[File]] {
+      val out =
+        managedResourceDirectories.in(Compile).value.head / "munit.properties"
+      val props = new java.util.Properties()
+      munitRepository.value.foreach { repo =>
+        props.put("munitRepository", repo)
+      }
+      munitBucketName.value.foreach { repo =>
+        props.put("munitBucketName", repo)
+      }
+      IO.write(props, "MUnit properties", out)
+      List(out)
+    }
+  )
+}

--- a/munit-sbt/src/main/scala/munit/sbtmunit/MUnitTestReport.scala
+++ b/munit-sbt/src/main/scala/munit/sbtmunit/MUnitTestReport.scala
@@ -1,4 +1,4 @@
-package munit
+package munit.sbtmunit
 
 object MUnitTestReport {
   case class Summary(

--- a/munit-sbt/src/main/scala/munit/sbtmunit/MUnitTestsListener.scala
+++ b/munit-sbt/src/main/scala/munit/sbtmunit/MUnitTestsListener.scala
@@ -1,4 +1,4 @@
-package munit
+package munit.sbtmunit
 
 import sbt._
 import scala.collection.JavaConverters._

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -1,0 +1,5 @@
+package munit.sbtmunit
+
+object BuildInfo {
+  val munitVersion = "unknown"
+}

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -17,6 +17,9 @@
       "getting-started": {
         "title": "Getting started"
       },
+      "reports": {
+        "title": "Generating test reports"
+      },
       "scalatest": {
         "title": "Coming from ScalaTest"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -6,6 +6,7 @@
       "assertions",
       "fixtures",
       "filtering",
+      "reports",
       "scalatest",
       "troubleshooting"
     ]


### PR DESCRIPTION
Previously, we were storing test report date in Google Cloud but we were
not rendering the data anywhere. Now, we add a new "Test reports" page
on the website that displays some statistics about the test suite in the
MUnit repo.

Example:


<img width="847" alt="Screenshot 2020-01-26 at 22 31 03" src="https://user-images.githubusercontent.com/1408093/73142881-8e48f800-408b-11ea-9dda-cc20aac1b4ac.png">

The data is not very interesting at the moment since MUnit has a fairly small test suite.