### PR TITLE
Support truly async Scala.js test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ website/build/
 website/yarn.lock
 website/node_modules
 website/i18n/*
-!website/i18n/en.json
 
 project/metals.sbt
 out/

--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,7 @@ addCommandAlias(
 val isPreScala213 = Set[Option[(Long, Long)]](Some((2, 11)), Some((2, 12)))
 val scala2Versions = List(scala211, scala212, scala213)
 val scalaVersions = scala2Versions ++ List(dotty)
+def isNotScala211(v: Option[(Long, Long)]): Boolean = !v.contains((2, 11))
 def isScala2(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2)
 def isScala3(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 0)
 val isScalaJS = Def.setting[Boolean](
@@ -113,6 +114,9 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       }
       if (isPreScala213(partialVersion)) {
         result += base / "scala-pre-2.13"
+      }
+      if (isNotScala211(partialVersion)) {
+        result += base / "scala-post-2.11"
       }
       if (isScala2(partialVersion)) {
         result += base / "scala-2"

--- a/munit-sbt/src/main/scala/munit/sbtmunit/MUnitReportPlugin.scala
+++ b/munit-sbt/src/main/scala/munit/sbtmunit/MUnitReportPlugin.scala
@@ -6,7 +6,7 @@ import MUnitPlugin.autoImport._
 
 object MUnitReportPlugin extends AutoPlugin {
   override def requires = MUnitPlugin
-  override val projectSettings = List(
+  override val projectSettings: List[Setting[_ <: Seq[Object]]] = List(
     libraryDependencies ++= {
       if ("unknown" == BuildInfo.munitVersion) Nil
       else List("org.scalameta" %% "munit-docs" % BuildInfo.munitVersion)

--- a/munit/jvm/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/jvm/src/main/scala/munit/internal/PlatformCompat.scala
@@ -1,15 +1,28 @@
 package munit.internal
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.Await
 import scala.concurrent.Future
+import sbt.testing.Task
+import sbt.testing.EventHandler
+import sbt.testing.Logger
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.Try
 
 object PlatformCompat {
+  def executeAsync(
+      task: Task,
+      eventHandler: EventHandler,
+      loggers: Array[Logger]
+  ): Future[Unit] = {
+    task.execute(eventHandler, loggers)
+    Future.successful(())
+  }
+  def waitAtMost[T](future: Future[T], duration: Duration): Future[T] = {
+    Future.fromTry(Try(Await.result(future, duration)))
+  }
+
   def isIgnoreSuite(cls: Class[_]): Boolean =
     cls.getAnnotationsByType(classOf[munit.IgnoreSuite]).nonEmpty
-  def await[T](f: Future[T], timeout: Duration): T = {
-    Await.result(f, timeout)
-  }
   def isJVM: Boolean = true
   def isJS: Boolean = false
   def isNative: Boolean = false

--- a/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
@@ -3,27 +3,31 @@ package munit.internal
 import sbt.testing.TaskDef
 import munit.MUnitRunner
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
 import scala.scalanative.testinterface.PreloadedClassLoader
+import sbt.testing.Task
+import sbt.testing.EventHandler
+import sbt.testing.Logger
+import scala.concurrent.duration.Duration
 
 object PlatformCompat {
+  def executeAsync(
+      task: Task,
+      eventHandler: EventHandler,
+      loggers: Array[Logger]
+  ): Future[Unit] = {
+    task.execute(eventHandler, loggers)
+    Future.successful(())
+  }
+  def waitAtMost[T](future: Future[T], duration: Duration): Future[T] = {
+    future
+  }
+
   // Scala Native does not support looking up annotations at runtime.
   def isIgnoreSuite(cls: Class[_]): Boolean = false
 
   def isJVM: Boolean = false
   def isJS: Boolean = false
   def isNative: Boolean = true
-
-  def await[T](f: Future[T], timeout: Duration): T = {
-    f.value match {
-      case Some(value) =>
-        value.get
-      case None =>
-        throw new NoSuchElementException(
-          s"Future $f is not completed and `scala.concurrent.Await` is not supported in Scala Native."
-        )
-    }
-  }
 
   def newRunner(
       taskDef: TaskDef,

--- a/munit/non-jvm/src/main/scala/com/geirsson/junit/JUnitReporter.scala
+++ b/munit/non-jvm/src/main/scala/com/geirsson/junit/JUnitReporter.scala
@@ -44,19 +44,18 @@ final class JUnitReporter(
     }
     emitEvent(method, Status.Skipped, new OptionalThrowable(e))
   }
-  def reportTestPassed(method: String, elapsedSeconds: Double): Unit = {
+  def reportTestPassed(method: String, elapsedMillis: Double): Unit = {
     log(
       Info,
-      AnsiColors.c(s"+ $method", AnsiColors.GREEN) + " " + formatTime(
-        elapsedSeconds
-      )
+      AnsiColors.c(s"+ $method", AnsiColors.GREEN) + " " +
+        formatTime(elapsedMillis)
     )
     emitEvent(method, Status.Success)
   }
   def reportTestFailed(
       method: String,
       ex: Throwable,
-      elapsedSeconds: Double
+      elapsedMillis: Double
   ): Unit = {
     log(
       Info,
@@ -68,7 +67,7 @@ final class JUnitReporter(
           )
         )
         .append(" ")
-        .append(formatTime(elapsedSeconds))
+        .append(formatTime(elapsedMillis))
         .append(" ")
         .append(ex.getClass().getName())
         .append(": ")
@@ -258,8 +257,8 @@ final class JUnitReporter(
       .append(AnsiColors.Reset)
       .toString()
   }
-  private def formatTime(elapsedSeconds: Double): String =
-    AnsiColors.c("%.2fs".format(elapsedSeconds), AnsiColors.DarkGrey)
+  private def formatTime(elapsedMillis: Double): String =
+    AnsiColors.c("%.2fs".format(elapsedMillis / 1000.0), AnsiColors.DarkGrey)
   private val Trace = 0
   private val Debug = 1
   private val Info = 2

--- a/munit/non-jvm/src/main/scala/com/geirsson/junit/JUnitTask.scala
+++ b/munit/non-jvm/src/main/scala/com/geirsson/junit/JUnitTask.scala
@@ -7,6 +7,7 @@ package com.geirsson.junit
 import munit.internal.PlatformCompat
 import org.junit.runner.notification.RunNotifier
 import sbt.testing._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 /* Implementation note: In JUnitTask we use Future[Try[Unit]] instead of simply
  * Future[Unit]. This is to prevent Scala's Future implementation to box/wrap
@@ -42,8 +43,7 @@ final class JUnitTask(
         val reporter =
           new JUnitReporter(eventHandler, loggers, runSettings, taskDef)
         val notifier: RunNotifier = new MUnitRunNotifier(reporter)
-        runner.run(notifier)
-        continuation(Array())
+        runner.runAsync(notifier).foreach(_ => continuation(Array()))
     }
   }
 

--- a/munit/shared/src/main/scala-2.11/munit/internal/FutureCompat.scala
+++ b/munit/shared/src/main/scala-2.11/munit/internal/FutureCompat.scala
@@ -1,0 +1,24 @@
+package munit.internal
+
+import scala.concurrent.Future
+import scala.util.Try
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Promise
+
+object FutureCompat {
+  implicit class ExtensionFuture[T](f: Future[T]) {
+    def flattenCompat[S](
+        ec: ExecutionContext
+    )(implicit ev: T <:< Future[S]): Future[S] =
+      f.flatMap(ev)(ec)
+    def transformCompat[B](
+        fn: Try[T] => Try[B]
+    )(implicit ec: ExecutionContext): Future[B] = {
+      val p = Promise[B]()
+      f.onComplete { t =>
+        p.complete(fn(t))
+      }
+      p.future
+    }
+  }
+}

--- a/munit/shared/src/main/scala-post-2.11/munit/internal/FutureCompat.scala
+++ b/munit/shared/src/main/scala-post-2.11/munit/internal/FutureCompat.scala
@@ -1,0 +1,19 @@
+package munit.internal
+
+import scala.concurrent.Future
+import scala.util.Try
+import scala.concurrent.ExecutionContext
+
+object FutureCompat {
+  implicit class ExtensionFuture[T](f: Future[T]) {
+    def flattenCompat[S](
+        ec: ExecutionContext
+    )(implicit ev: T <:< Future[S]): Future[S] =
+      f.flatten
+    def transformCompat[B](
+        fn: Try[T] => Try[B]
+    )(implicit ec: ExecutionContext): Future[B] = {
+      f.transform(fn)
+    }
+  }
+}

--- a/munit/shared/src/main/scala/munit/Suite.scala
+++ b/munit/shared/src/main/scala/munit/Suite.scala
@@ -1,6 +1,7 @@
 package munit
 
 import org.junit.runner.RunWith
+import scala.concurrent.ExecutionContext
 
 /** The base class for all test suites.
   * Extend this class if you don't need the functionality in FunSuite.
@@ -19,6 +20,12 @@ abstract class Suite extends PlatformSuite {
 
   /** Functinonal fixtures that can be reused for individual test cases or entire suites. */
   def munitFixtures: Seq[Fixture[_]] = Nil
+
+  private val parasiticExecutionContext = new ExecutionContext {
+    def execute(runnable: Runnable): Unit = runnable.run()
+    def reportFailure(cause: Throwable): Unit = cause.printStackTrace()
+  }
+  def munitExecutionContext: ExecutionContext = parasiticExecutionContext
 
   /**
     *

--- a/tests/js/src/test/scala/munit/AsyncJSSuite.scala
+++ b/tests/js/src/test/scala/munit/AsyncJSSuite.scala
@@ -1,0 +1,21 @@
+package munit
+
+import scala.concurrent.Promise
+
+class AsyncJSSuite extends FunSuite {
+  test("async-ok") {
+    val p = Promise[Unit]()
+    scala.scalajs.js.timers.setTimeout(100) {
+      p.success(())
+    }
+    p.future
+  }
+
+  test("async-error".fail) {
+    val p = Promise[Unit]()
+    scala.scalajs.js.timers.setTimeout(100) {
+      p.failure(new RuntimeException("boom"))
+    }
+    p.future
+  }
+}

--- a/tests/jvm/src/test/scala/munit/FutureSuite.scala
+++ b/tests/jvm/src/test/scala/munit/FutureSuite.scala
@@ -1,0 +1,19 @@
+package munit
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class FutureSuite extends FunSuite {
+  test("nested".fail) {
+    Future {
+      Thread.sleep(2)
+      Future {
+        Thread.sleep(2)
+        Future {
+          Thread.sleep(2)
+          ???
+        }
+      }
+    }
+  }
+}

--- a/tests/shared/src/main/scala/munit/FixtureFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/FixtureFrameworkSuite.scala
@@ -1,6 +1,7 @@
 package munit
 
 class FixtureFrameworkSuite extends FunSuite {
+  def println(msg: String): Unit = TestingConsole.out.println(msg)
   private def fixture(name: String) = new Fixture[Int](name) {
     def apply(): Int = 1
     override def beforeAll(): Unit = {

--- a/tests/shared/src/main/scala/munit/TestingConsole.scala
+++ b/tests/shared/src/main/scala/munit/TestingConsole.scala
@@ -1,0 +1,8 @@
+package munit
+
+import java.io.PrintStream
+
+object TestingConsole {
+  var out: PrintStream = System.out
+  var err: PrintStream = System.err
+}

--- a/tests/shared/src/test/scala/munit/BaseSuite.scala
+++ b/tests/shared/src/test/scala/munit/BaseSuite.scala
@@ -1,19 +1,23 @@
 package munit
 
 import munit.internal.PlatformCompat
+import scala.concurrent.Future
 
 class BaseSuite extends FunSuite {
-  override def munitRunTest(options: TestOptions, body: => Any): Any = {
+  override def munitRunTest(
+      options: TestOptions,
+      body: () => Future[Any]
+  ): Future[Any] = {
     def isDotty: Boolean =
       BuildInfo.scalaVersion.startsWith("0.")
     def is213: Boolean =
       BuildInfo.scalaVersion.startsWith("2.13") || isDotty
     if (options.tags(NoDotty) && isDotty) {
-      Ignore
+      Future.successful(Ignore)
     } else if (options.tags(Only213) && !is213) {
-      Ignore
+      Future.successful(Ignore)
     } else if (options.tags(OnlyJVM) && !PlatformCompat.isJVM) {
-      Ignore
+      Future.successful(Ignore)
     } else {
       super.munitRunTest(options, body)
     }

--- a/tests/shared/src/test/scala/munit/LazyFutureSuite.scala
+++ b/tests/shared/src/test/scala/munit/LazyFutureSuite.scala
@@ -1,0 +1,25 @@
+package munit
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+class LazyFutureSuite extends FunSuite {
+  implicit val ec: ExecutionContext = ExecutionContext.global
+  case class LazyFuture[+T](run: () => Future[T])
+  object LazyFuture {
+    def apply[T](thunk: => T)(implicit ec: ExecutionContext): LazyFuture[T] =
+      LazyFuture(() => Future(thunk))
+  }
+  override def munitTestValue(testValue: => Any): Future[Any] =
+    super.munitTestValue(testValue).flatMap {
+      case LazyFuture(run) => run()
+      case value           => Future.successful(value)
+    }
+
+  test("ok-task".fail) {
+    LazyFuture {
+      // Test will fail because  LazyFuture.run()` is automatically called
+      throw new RuntimeException("BOOM!")
+    }
+  }
+}

--- a/tests/shared/src/test/scala/munit/TestLocalFixtureSuite.scala
+++ b/tests/shared/src/test/scala/munit/TestLocalFixtureSuite.scala
@@ -13,7 +13,7 @@ class TestLocalFixtureSuite extends FunSuite {
   }
   val name2 = name
 
-  override def afterEach(context: GenericAfterEach[Any]): Unit = {
+  override def afterEach(context: GenericAfterEach[TestValue]): Unit = {
     assertEquals(name(), context.test.name + "-after")
   }
 

--- a/website/blog/2020-02-01-hello-world.md
+++ b/website/blog/2020-02-01-hello-world.md
@@ -95,11 +95,11 @@ JUnit and MUnit test cases are not generated via macros like in utest.
 
 MUnit provides a high-level API to write tests in a ScalaTest-inspired
 `FunSuite` syntax where the type parameter for `GenericTest[T]` is defined as
-`Any`.
+`Future[Any]`.
 
 ```scala
 abstract class FunSuite extends Suite {
-  type TestValue = Any
+  type TestValue = Future[Any]
 }
 ```
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -6,7 +6,7 @@
     "tagline": "Scala testing library with actionable errors and extensible APIs",
     "docs": {
       "assertions": {
-        "title": "Writing assertions"
+        "title": "assertions"
       },
       "filtering": {
         "title": "Filtering tests"


### PR DESCRIPTION
Previously, we didn't really support properly async tests. While we were
able to work around this limitation on the JVM with blocking operations,
it made MUnit mostly unusable with Scala.js.  Now, the evaluation of
test cases has been changed so that test evaluation is encoded as a
`Future[Any]` allowing the Scala.js test runner to block until all tests
are finished.

It requires a fairly breaking change in the public API of `FunSuite` to
support truly async tests. The `TestValue` type parameter has changed
from `Any` to `Future[Any]` and the same change has been reflected in
most signatures of methods that users may override such as
`munitRunTest`. I'm quite happy with these breking changes since I found
it much easier to reason about custom modifiers like `.fail` and
`.flaky` when the test body is wrapped in `Future`.