### PR TITLE
Added message check to intercept assertion

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -1,3 +1,4 @@
+
 ---
 id: assertions
 title: Writing assertions
@@ -132,6 +133,22 @@ ignores non-visible differences such as trailing/leading whitespace,
 Windows/Unix newlines and ANSI color codes. The "=> Obtained" section of
 `assertNoDiff()` error messages also include copy-paste friendly syntax using
 `.stripMargin`.
+
+## `intercept()`
+Use `intercept()` when you expect a particular exception to be thrown by the test code (i.e. the test succeeds if the given Exception is thrown)
+```scala mdoc:crash
+intercept[java.lang.IllegalArgumentException]{
+   // code expected to throw exception here
+}
+```
+Optionally you can expect a specific message for the given Exception if you need more than to test only the presence of a given Exception:
+```scala mdoc:crash
+intercept[java.lang.IllegalArgumentException]({
+   // code expected to throw exception here
+},"argument type mismatch")
+```
+
+
 
 ## `fail()`
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -141,14 +141,14 @@ intercept[java.lang.IllegalArgumentException]{
    // code expected to throw exception here
 }
 ```
-Optionally you can expect a specific message for the given Exception if you need more than to test only the presence of a given Exception:
+
+## `interceptMessage()`
+Like intercept() except you can also specify a specific message the given Exception must match.
 ```scala mdoc:crash
-intercept[java.lang.IllegalArgumentException]({
+interceptMessage[java.lang.IllegalArgumentException]("argument type mismatch"){
    // code expected to throw exception here
-},"argument type mismatch")
+}
 ```
-
-
 
 ## `fail()`
 

--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -120,7 +120,7 @@ trait Assertions {
           else {
             val obtained = e.getClass().getName()
             throw new FailException(
-              s"intercept failed, exception '$obtained' had message '${e.getMessage}', which was different from expected message '$msg'",
+              s"intercept failed, exception '$obtained' had message '${e.getMessage}', which was different from expected message '${msg.get}'",
               cause = e,
               isStackTracesEnabled = false,
               location = loc

--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -92,17 +92,17 @@ trait Assertions {
   def intercept[T <: Throwable](
       body: => Any
   )(implicit T: ClassTag[T], loc: Location): T = {
-    _intercept(None, body)
+    runIntercept(None, body)
   }
 
-  def interceptMessage[T <: Throwable](msg: String)(
+  def interceptMessage[T <: Throwable](expectedExceptionMessage: String)(
       body: => Any
   )(implicit T: ClassTag[T], loc: Location): T = {
-    _intercept(Some(msg), body)
+    runIntercept(Some(expectedExceptionMessage), body)
   }
 
-  private def _intercept[T <: Throwable](
-      msg: Option[String],
+  private def runIntercept[T <: Throwable](
+      expectedExceptionMessage: Option[String],
       body: => Any
   )(implicit T: ClassTag[T], loc: Location): T = {
     try {
@@ -115,12 +115,12 @@ trait Assertions {
         throw e
       case NonFatal(e) =>
         if (T.runtimeClass.isAssignableFrom(e.getClass())) {
-          if (msg.isEmpty || e.getMessage == msg.get)
+          if (expectedExceptionMessage.isEmpty || e.getMessage == expectedExceptionMessage.get)
             e.asInstanceOf[T]
           else {
             val obtained = e.getClass().getName()
             throw new FailException(
-              s"intercept failed, exception '$obtained' had message '${e.getMessage}', which was different from expected message '${msg.get}'",
+              s"intercept failed, exception '$obtained' had message '${e.getMessage}', which was different from expected message '${expectedExceptionMessage.get}'",
               cause = e,
               isStackTracesEnabled = false,
               location = loc

--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -90,8 +90,20 @@ trait Assertions {
   }
 
   def intercept[T <: Throwable](
-      body: => Any,
-      msg: String = ""
+      body: => Any
+  )(implicit T: ClassTag[T], loc: Location): T = {
+    _intercept(None,body)
+  }
+
+  def interceptMessage[T <: Throwable](msg: String)(
+      body: => Any
+  )(implicit T: ClassTag[T], loc: Location): T = {
+    _intercept(Some(msg),body)
+  }
+
+  private def _intercept[T <: Throwable](
+      msg: Option[String],
+      body: => Any
   )(implicit T: ClassTag[T], loc: Location): T = {
     try {
       body
@@ -103,7 +115,7 @@ trait Assertions {
         throw e
       case NonFatal(e) =>
         if (T.runtimeClass.isAssignableFrom(e.getClass())) {
-          if (msg == "" || e.getMessage == msg)
+          if (msg.isEmpty || e.getMessage == msg.get)
             e.asInstanceOf[T]
           else {
             val obtained = e.getClass().getName()

--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -92,13 +92,13 @@ trait Assertions {
   def intercept[T <: Throwable](
       body: => Any
   )(implicit T: ClassTag[T], loc: Location): T = {
-    _intercept(None,body)
+    _intercept(None, body)
   }
 
   def interceptMessage[T <: Throwable](msg: String)(
       body: => Any
   )(implicit T: ClassTag[T], loc: Location): T = {
-    _intercept(Some(msg),body)
+    _intercept(Some(msg), body)
   }
 
   private def _intercept[T <: Throwable](

--- a/tests/shared/src/main/scala/munit/InterceptFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/InterceptFrameworkSuite.scala
@@ -9,7 +9,7 @@ class InterceptFrameworkSuite extends FunSuite {
     intercept[InterceptException](???)
   }
   test("intercept-message-match") {
-    interceptMessage[NotImplementedError]("boom") {???}
+    interceptMessage[NotImplementedError]("boom") { ??? }
   }
 }
 

--- a/tests/shared/src/main/scala/munit/InterceptFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/InterceptFrameworkSuite.scala
@@ -8,6 +8,9 @@ class InterceptFrameworkSuite extends FunSuite {
   test("type-mismatch") {
     intercept[InterceptException](???)
   }
+  test("intercept-message-match") {
+    intercept[NotImplementedError](???,"boom")
+  }
 }
 
 object InterceptFrameworkSuite
@@ -15,5 +18,6 @@ object InterceptFrameworkSuite
       classOf[InterceptFrameworkSuite],
       """|==> success munit.InterceptFrameworkSuite.not-implemented
          |==> failure munit.InterceptFrameworkSuite.type-mismatch - intercept failed, exception 'scala.NotImplementedError' is not a subtype of 'munit.InterceptException
+         |==> failure munit.InterceptFrameworkSuite.intercept-message-match - intercept failed, exception 'scala.NotImplementedError' had message 'an implementation is missing', which was different from expected message 'boom'
          |""".stripMargin
     )

--- a/tests/shared/src/main/scala/munit/InterceptFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/InterceptFrameworkSuite.scala
@@ -9,7 +9,7 @@ class InterceptFrameworkSuite extends FunSuite {
     intercept[InterceptException](???)
   }
   test("intercept-message-match") {
-    intercept[NotImplementedError](???, "boom")
+    interceptMessage[NotImplementedError]("boom"){???}
   }
 }
 

--- a/tests/shared/src/main/scala/munit/InterceptFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/InterceptFrameworkSuite.scala
@@ -9,7 +9,7 @@ class InterceptFrameworkSuite extends FunSuite {
     intercept[InterceptException](???)
   }
   test("intercept-message-match") {
-    intercept[NotImplementedError](???,"boom")
+    intercept[NotImplementedError](???, "boom")
   }
 }
 

--- a/tests/shared/src/main/scala/munit/InterceptFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/InterceptFrameworkSuite.scala
@@ -9,7 +9,7 @@ class InterceptFrameworkSuite extends FunSuite {
     intercept[InterceptException](???)
   }
   test("intercept-message-match") {
-    interceptMessage[NotImplementedError]("boom"){???}
+    interceptMessage[NotImplementedError]("boom") {???}
   }
 }
 

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -2,7 +2,7 @@ package munit
 
 class FrameworkSuite extends BaseFrameworkSuite {
   val tests: List[FrameworkTest] = List[FrameworkTest](
-    // InterceptFrameworkSuite,
+    InterceptFrameworkSuite,
     CiOnlyFrameworkSuite,
     DiffProductFrameworkSuite,
     FailFrameworkSuite,


### PR DESCRIPTION
Added a check to existing intercept assertion to (optionally) validate that the expected exception's message matches an expected value.  If no message is given, intercept() works as it does today.

Added documentation for intercept().