### PR TITLE
Fix bug where exceptions without stack traces cause test success.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -151,7 +151,7 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     skip in publish := customScalaJSVersion.isDefined,
     libraryDependencies ++= List(
       "junit" % "junit" % "4.13",
-      "com.geirsson" % "junit-interface" % "0.11.9"
+      "com.geirsson" % "junit-interface" % "0.11.11"
     )
   )
 lazy val munitJVM = munit.jvm

--- a/tests/shared/src/main/scala/munit/SwallowedExceptionSuite.scala
+++ b/tests/shared/src/main/scala/munit/SwallowedExceptionSuite.scala
@@ -1,0 +1,15 @@
+package munit
+
+import scala.util.control.NoStackTrace
+
+class SwallowedExceptionSuite extends FunSuite {
+  test("issue-51") {
+    throw new Exception("i am not reported") with NoStackTrace
+  }
+}
+object SwallowedExceptionSuite
+    extends FrameworkTest(
+      classOf[SwallowedExceptionSuite],
+      """|==> failure munit.SwallowedExceptionSuite.issue-51 - i am not reported
+         |""".stripMargin
+    )

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -2,6 +2,7 @@ package munit
 
 class FrameworkSuite extends BaseFrameworkSuite {
   val tests: List[FrameworkTest] = List[FrameworkTest](
+    SwallowedExceptionSuite,
     InterceptFrameworkSuite,
     CiOnlyFrameworkSuite,
     DiffProductFrameworkSuite,


### PR DESCRIPTION
Fixes #51. Previously, uncaught exceptions without stack traces did not cause the test fail. This upgrade to the latest junit-interface version fixes the issue and this commit adds a test case to prevent future regressions.