### PR TITLE
Move junit-interface into the MUnit codebase.

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -52,3 +52,37 @@ MUnit contains parts which are derived from
 [the Scalameta project](https://github.com/scalameta/scalameta). The original
 license can be found here:
 https://github.com/scalameta/scalameta/blob/master/LICENSE.md
+
+# License notice for junit-interface
+
+MUnit contains parts which are derived from [the JUnit 4 interface for
+sbt](https://github.com/sbt/junit-interface). We include the text of the
+original license below:
+
+```
+Copyright (c) 2009-2012, Stefan Zeiger
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+```
+

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ def scala212 = "2.12.10"
 def scala211 = "2.11.12"
 def dotty = "0.22.0-RC1"
 def scalameta = "4.3.0"
+def junitVersion = "4.13"
 def gcp = "com.google.cloud" % "google-cloud-storage" % "1.103.0"
 inThisBuild(
   List(
@@ -100,6 +101,22 @@ val sharedSettings = List(
   }
 )
 
+lazy val junit = project
+  .in(file("junit-interface"))
+  .settings(
+    moduleName := "junit-interface",
+    description := "A Java implementation of sbt's test interface for JUnit 4",
+    autoScalaLibrary := false,
+    crossPaths := false,
+    sbtPlugin := false,
+    libraryDependencies ++= Seq(
+      "junit" % "junit" % junitVersion,
+      "org.scala-sbt" % "test-interface" % "1.0"
+    ),
+    javacOptions in Compile ++= List("-target", "1.8", "-source", "1.8"),
+    javacOptions in (Compile, doc) --= List("-target", "1.8")
+  )
+
 lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     sharedSettings,
@@ -154,10 +171,10 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .jvmSettings(
     skip in publish := customScalaJSVersion.isDefined,
     libraryDependencies ++= List(
-      "junit" % "junit" % "4.13",
-      "com.geirsson" % "junit-interface" % "0.11.11"
+      "junit" % "junit" % "4.13"
     )
   )
+  .jvmConfigure(_.dependsOn(junit))
 lazy val munitJVM = munit.jvm
 lazy val munitJS = munit.js
 lazy val munitNative = munit.native

--- a/junit-interface/src/main/java/munit/internal/junitinterface/AbstractAnnotatedFingerprint.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/AbstractAnnotatedFingerprint.java
@@ -1,0 +1,12 @@
+package munit.internal.junitinterface;
+
+import sbt.testing.AnnotatedFingerprint;
+
+public abstract class AbstractAnnotatedFingerprint implements AnnotatedFingerprint {
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof AnnotatedFingerprint)) return false;
+    AnnotatedFingerprint f = (AnnotatedFingerprint) obj;
+    return annotationName().equals(f.annotationName()) && isModule() == f.isModule();
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/AbstractEvent.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/AbstractEvent.java
@@ -1,0 +1,65 @@
+package munit.internal.junitinterface;
+
+import sbt.testing.*;
+
+import static munit.internal.junitinterface.Ansi.*;
+
+abstract class AbstractEvent implements Event
+{
+  protected final String ansiName;
+  protected final String ansiMsg;
+  protected final Status status;
+  protected final Throwable error;
+  private final Fingerprint fingerprint;
+  private final Long duration;
+
+  AbstractEvent(String ansiName, String ansiMsg, Status status, Fingerprint fingerprint, Long duration, Throwable error)
+  {
+    this.fingerprint = fingerprint;
+    this.ansiName = ansiName;
+    this.ansiMsg = ansiMsg;
+    this.status = status;
+    this.duration = duration;
+    this.error = error;
+  }
+
+  abstract void logTo(RichLogger logger);
+
+  @Override
+  public String fullyQualifiedName() {
+    return filterAnsi(ansiName);
+  }
+
+  @Override
+  public Fingerprint fingerprint() {
+    return fingerprint;
+  }
+
+  @Override
+  public Selector selector() {
+    return new TestSelector(fullyQualifiedName());
+  }
+
+  @Override
+  public Status status() {
+    return status;
+  }
+
+  @Override
+  public OptionalThrowable throwable() {
+    if( error == null ) {
+      return new OptionalThrowable();
+    } else {
+      return new OptionalThrowable(error);
+    }
+  }
+
+  @Override
+  public long duration() {
+    return duration;
+  }
+
+  String durationToString() {
+    return c(duration / 1000.0 + "s", FAINT);
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/Ansi.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/Ansi.java
@@ -1,0 +1,68 @@
+package munit.internal.junitinterface;
+
+public class Ansi {
+  // Standard ANSI sequences
+  private static final String NORMAL = "\u001B[0m";
+  private static final String HIGH_INTENSITY = "\u001B[1m";
+  private static final String LOW_INTESITY = "\u001B[2m";
+  private static final String BLACK = "\u001B[30m";
+  private static final String RED = "\u001B[31m";
+  private static final String GREEN = "\u001B[32m";
+  private static final String YELLOW = "\u001B[33m";
+  private static final String BLUE = "\u001B[34m";
+  private static final String MAGENTA = "\u001B[35m";
+  private static final String CYAN = "\u001B[36m";
+  private static final String WHITE = "\u001B[37m";
+
+  private static final String DARK_GREY = "\u001B[90m";
+  private static final String LIGHT_RED = "\u001B[91m";
+  private static final String LIGHT_GREEN = "\u001B[92m";
+  private static final String LIGHT_YELLOW = "\u001B[93m";
+  private static final String LIGHT_BLUE = "\u001B[94m";
+  private static final String LIGHT_MAGENTA = "\u001B[95m";
+  private static final String LIGHT_CYAN = "\u001B[96m";
+
+  public static String c(String s, String colorSequence)
+  {
+    if(colorSequence == null) return s;
+    else return colorSequence + s + NORMAL;
+  }
+
+  public static String filterAnsi(String s)
+  {
+    if(s == null) return null;
+    StringBuilder b = new StringBuilder(s.length());
+    int len = s.length();
+    for(int i=0; i<len; i++)
+    {
+      char c = s.charAt(i);
+      if(c == '\u001B')
+      {
+        do { i++; } while(s.charAt(i) != 'm');
+      }
+      else b.append(c);
+    }
+    return b.toString();
+  }
+
+  private Ansi() {}
+
+  public static final String INFO = LIGHT_BLUE;
+  public static final String SKIPPED = YELLOW;
+  public static final String SUCCESS1 = GREEN;
+  public static final String SUCCESS2 = GREEN;
+  public static final String ERRCOUNT = LIGHT_RED;
+  public static final String IGNCOUNT = YELLOW;
+  public static final String WARNMSG = LIGHT_YELLOW;
+  public static final String ERRMSG = LIGHT_RED;
+  public static final String NNAME1 = YELLOW;
+  public static final String NNAME2 = YELLOW;
+  public static final String NNAME3 = YELLOW;
+  public static final String ENAME1 = YELLOW;
+  public static final String ENAME2 = LIGHT_RED;
+  public static final String ENAME3 = YELLOW;
+  public static final String FAILURE1 = LIGHT_RED;
+  public static final String FAILURE2 = LIGHT_RED;
+  public static final String BOLD = HIGH_INTENSITY;
+  public static final String FAINT = DARK_GREY;
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/CustomFingerprint.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/CustomFingerprint.java
@@ -1,0 +1,45 @@
+package munit.internal.junitinterface;
+
+import sbt.testing.SubclassFingerprint;
+
+public class CustomFingerprint implements SubclassFingerprint {
+  final String suite;
+  final String runner;
+  final boolean module;
+
+  public CustomFingerprint(String suite, String runner, boolean module) {
+    this.suite = suite;
+    this.runner = runner;
+    this.module = module;
+  }
+
+  public static CustomFingerprint of(String suite, String runner) {
+    return new CustomFingerprint(suite, runner, false);
+  }
+
+  public static CustomFingerprint ofModule(String suite, String runner) {
+    return new CustomFingerprint(suite, runner, true);
+  }
+
+  @Override
+  public boolean isModule() {
+    return module;
+  }
+
+  @Override
+  public String superclassName() {
+    return suite;
+  }
+
+  @Override
+  public boolean requireNoArgConstructor() {
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "CustomFingerprint{" +
+        "suite='" + suite + '\'' +
+        '}';
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/CustomRunners.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/CustomRunners.java
@@ -1,0 +1,43 @@
+package munit.internal.junitinterface;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import sbt.testing.Fingerprint;
+import sbt.testing.SubclassFingerprint;
+
+public class CustomRunners {
+  final List<CustomFingerprint> runners;
+  final Set<String> superclasses;
+
+  public CustomRunners(List<CustomFingerprint> runners) {
+    this.runners = runners;
+    this.superclasses = new HashSet<>();
+    runners.forEach(runner -> this.superclasses.add(runner.suite));
+  }
+  public boolean isEmpty() {
+    return runners.isEmpty();
+  }
+
+  public Map<String, String> all() {
+      Map<String, String> result = new HashMap<>();
+      runners.forEach(runner -> result.put(runner.suite, runner.runner));
+      return result;
+  }
+
+  public boolean matchesFingerprint(Fingerprint fingerprint) {
+    if (fingerprint instanceof SubclassFingerprint) {
+      SubclassFingerprint subclassFingerprint = (SubclassFingerprint) fingerprint;
+      return superclasses.contains(subclassFingerprint.superclassName());
+    }
+    return false;
+  }
+
+  public static CustomRunners of(CustomFingerprint... runners) {
+    return new CustomRunners(Arrays.asList(runners));
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/CustomSuperclasses.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/CustomSuperclasses.java
@@ -1,0 +1,22 @@
+package munit.internal.junitinterface;
+
+
+import java.util.Set;
+import sbt.testing.Fingerprint;
+import sbt.testing.SubclassFingerprint;
+
+public class CustomSuperclasses {
+  final Set<String> superclasses;
+
+  public CustomSuperclasses(Set<String> superclasses) {
+    this.superclasses = superclasses;
+  }
+
+  public boolean matchesFingerprint(Fingerprint fingerprint) {
+    if (fingerprint instanceof SubclassFingerprint) {
+      SubclassFingerprint subclassFingerprint = (SubclassFingerprint) fingerprint;
+      return superclasses.contains(subclassFingerprint.superclassName());
+    }
+    return false;
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/EmptyRunner.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/EmptyRunner.java
@@ -1,0 +1,18 @@
+package munit.internal.junitinterface;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+
+class EmptyRunner extends Runner {
+
+  private final Description desc;
+
+  EmptyRunner(Description desc) { this.desc = desc; } 
+
+  @Override
+  public Description getDescription() { return desc; }
+
+  @Override
+  public void run(RunNotifier notifier) {}
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
@@ -1,0 +1,251 @@
+package munit.internal.junitinterface;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.io.IOException;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import sbt.testing.EventHandler;
+import sbt.testing.Fingerprint;
+import sbt.testing.Status;
+
+import static munit.internal.junitinterface.Ansi.*;
+
+
+final class EventDispatcher extends RunListener
+{
+  private final RichLogger logger;
+  private final Set<String> reported = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+  private final Set<String> reportedSuites = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+  private final ConcurrentHashMap<String, Long> startTimes = new ConcurrentHashMap<String, Long>();
+  private final EventHandler handler;
+  private final RunSettings settings;
+  private final Fingerprint fingerprint;
+  private final String taskInfo;
+  private final RunStatistics runStatistics;
+  private OutputCapture capture;
+
+  EventDispatcher(RichLogger logger, EventHandler handler, RunSettings settings, Fingerprint fingerprint,
+                  Description taskDescription, RunStatistics runStatistics)
+  {
+    this.logger = logger;
+    this.handler = handler;
+    this.settings = settings;
+    this.fingerprint = fingerprint;
+    this.taskInfo = settings.buildPlainName(taskDescription);
+    this.runStatistics = runStatistics;
+  }
+
+  private abstract class Event extends AbstractEvent {
+    Event(String name, String message, Status status, Long duration, Throwable error) {
+      super(name, message, status, fingerprint, duration, error);
+    }
+    String durationSuffix() { return " " + durationToString(); }
+  }
+
+  private abstract class ErrorEvent extends Event {
+    ErrorEvent(Failure failure, Status status) {
+      super(settings.buildErrorName(failure.getDescription(), status),
+            settings.buildErrorMessage(failure.getException()),
+            status,
+            elapsedTime(failure.getDescription()),
+            failure.getException());
+    }
+  }
+
+  private abstract class InfoEvent extends Event {
+    InfoEvent(Description desc, Status status) {
+      super(settings.buildInfoName(desc, status), null, status, elapsedTime(desc), null);
+    }
+  }
+
+  @Override
+  public void testAssumptionFailure(final Failure failure)
+  {
+    uncapture(true);
+    postIfFirst(new ErrorEvent(failure, Status.Skipped) {
+      void logTo(RichLogger logger) {
+        if (settings.verbose) {
+          logger.info(Ansi.c("==> i "  + failure.getDescription().getMethodName(), WARNMSG));
+        }
+      }
+    });
+  }
+
+  @Override
+  public void testFailure(final Failure failure)
+  {
+    if (failure.getDescription() != null && failure.getDescription().getClassName() != null) {
+      try {
+        trimStackTrace(
+            failure.getException(),
+            "java.lang.Thread",
+            failure.getDescription().getClassName()
+        );
+      } catch (Throwable t) {
+        // Ignore error.
+      }
+    }
+    uncapture(true);
+    postIfFirst(new ErrorEvent(failure, Status.Failure) {
+      void logTo(RichLogger logger) {
+        logger.error( settings.buildTestResult(Status.Failure) +ansiName+" "+ durationSuffix() + " " + ansiMsg, error);
+      }
+    });
+  }
+
+
+  @Override
+  public void testFinished(Description desc)
+  {
+    uncapture(false);
+    postIfFirst(new InfoEvent(desc, Status.Success) {
+      void logTo(RichLogger logger) {
+        logger.info(settings.buildTestResult(Status.Success) +Ansi.c(desc.getMethodName(), SUCCESS1) + durationSuffix());
+      }
+    });
+    logger.popCurrentTestClassName();
+  }
+
+  @Override
+  public void testIgnored(Description desc)
+  {
+    postIfFirst(new InfoEvent(desc, Status.Skipped) {
+      void logTo(RichLogger logger) {
+        logger.warn(settings.buildTestResult(Status.Ignored) + ansiName+" ignored" + durationSuffix());
+      }
+    });
+  }
+
+
+  @Override
+  public void testSuiteStarted(Description description)
+  {
+    if (description == null || description.getClassName() == null || description.getClassName().equals("null")) return;
+    reportedSuites.add(description.getClassName());
+    logger.info(c(description.getClassName() + ":", SUCCESS1));
+  }
+
+
+  @Override
+  public void testStarted(Description description)
+  {
+    recordStartTime(description);
+    if (reportedSuites.add(description.getClassName())) {
+      testSuiteStarted(description);
+    }
+    logger.pushCurrentTestClassName(description.getClassName());
+    if (settings.verbose) {
+      logger.info(settings.buildPlainName(description) + " started");
+    }
+    capture();
+  }
+
+  private void recordStartTime(Description description) {
+    startTimes.putIfAbsent(settings.buildPlainName(description), System.currentTimeMillis());
+  }
+
+  private Long elapsedTime(Description description) {
+    Long startTime = startTimes.get(settings.buildPlainName(description));
+    if( startTime == null ) {
+      return 0l;
+    } else {
+      return System.currentTimeMillis() - startTime;
+    }
+  }
+
+  @Override
+  public void testRunFinished(Result result)
+  {
+      if (settings.verbose) {
+        logger.info("Test run " +taskInfo+" finished: "+
+          result.getFailureCount()+" failed" +
+          ", " +
+          result.getIgnoreCount()+" ignored" +
+          ", "+result.getRunCount()+" total, "+(result.getRunTime()/1000.0)+"s") ;
+      }
+    runStatistics.addTime(result.getRunTime());
+  }
+
+  @Override
+  public void testRunStarted(Description description)
+  {
+      if (settings.verbose) {
+        logger.info(taskInfo + " started");
+      }
+  }
+
+  void testExecutionFailed(String testName, Throwable err)
+  {
+    post(new Event(Ansi.c(testName, Ansi.ERRMSG), settings.buildErrorMessage(err), Status.Error, 0L, err) {
+      void logTo(RichLogger logger) {
+        logger.error(ansiName+" failed: "+ansiMsg, error);
+      }
+    });
+  }
+
+  private void postIfFirst(AbstractEvent e)
+  {
+    if(reported.add(e.fullyQualifiedName())) {
+      e.logTo(logger);
+      runStatistics.captureStats(e);
+      handler.handle(e);
+    }
+  }
+
+  void post(AbstractEvent e)
+  {
+    e.logTo(logger);
+    runStatistics.captureStats(e);
+    handler.handle(e);
+  }
+
+  private void capture()
+  {
+    if(settings.quiet && capture == null)
+      capture = OutputCapture.start();
+  }
+
+  void uncapture(boolean replay)
+  {
+    if(settings.quiet && capture != null)
+    {
+      capture.stop();
+      if(replay)
+      {
+        try { capture.replay(); }
+        catch(IOException ex) { logger.error("Error replaying captured stdio", ex); }
+      }
+      capture = null;
+    }
+  }
+
+
+  // Removes stack trace elements that reference the reflective invocation in TestLauncher.
+  private static void trimStackTrace(Throwable ex, String fromClassName, String toClassName) {
+    Throwable cause = ex;
+    while (cause != null) {
+      StackTraceElement[] stackTrace = cause.getStackTrace();
+      if (stackTrace != null && stackTrace.length > 0) {
+        int end = stackTrace.length - 1;
+        StackTraceElement last = stackTrace[end];
+        if (last.getClassName() != null && last.getClassName().equals(fromClassName)) {
+          for (int i = 0; end >= 0; end--) {
+            StackTraceElement e = stackTrace[end];
+            if (e.getClassName().equals(toClassName)) {
+              break;
+            }
+          }
+          StackTraceElement[] newStackTrace = Arrays.copyOfRange(stackTrace, 0, end + 1);
+          cause.setStackTrace(newStackTrace);
+        }
+      }
+      cause = cause.getCause();
+    }
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/GlobFilter.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/GlobFilter.java
@@ -1,0 +1,47 @@
+package munit.internal.junitinterface;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+
+public final class GlobFilter extends Filter
+{
+  private final ArrayList<Pattern> patterns = new ArrayList<Pattern>();
+  private final RunSettings settings;
+
+  public GlobFilter(RunSettings settings, Iterable<String> globPatterns)
+  {
+    this.settings = settings;
+    for(String p : globPatterns) patterns.add(compileGlobPattern(p));
+  }
+
+  @Override
+  public String describe() {
+    return "Filters out all tests not matched by the glob patterns";
+  }
+
+  @Override
+  public boolean shouldRun(Description d)
+  {
+    if(d.isSuite()) return true;
+    String plainName = settings.buildPlainName(d);
+
+    for(Pattern p : patterns)
+      if(p.matcher(plainName).matches()) return true;
+
+    return false;
+  }
+
+  private static Pattern compileGlobPattern(String expr) {
+    String[] a = expr.split("\\*", -1);
+    StringBuilder b = new StringBuilder();
+    for(int i=0; i<a.length; i++) {
+      if(i != 0) b.append(".*");
+      if(!a[i].isEmpty())
+        b.append(Pattern.quote(a[i].replaceAll("\n", "\\n")));
+    }
+    return Pattern.compile(b.toString());
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnit3Fingerprint.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnit3Fingerprint.java
@@ -1,0 +1,16 @@
+package munit.internal.junitinterface;
+
+import sbt.testing.SubclassFingerprint;
+
+
+public class JUnit3Fingerprint implements SubclassFingerprint
+{
+  @Override
+  public String superclassName() { return "junit.framework.TestCase"; }
+
+  @Override
+  public boolean isModule() { return false; }
+
+  @Override
+  public boolean requireNoArgConstructor() { return false; }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitComputer.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitComputer.java
@@ -1,0 +1,81 @@
+package munit.internal.junitinterface;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.runner.Computer;
+import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.Filterable;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runners.Suite;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerBuilder;
+
+public class JUnitComputer extends Computer {
+  final Map<Class<?>, Class<?>> suiteRunners;
+
+  public JUnitComputer(ClassLoader testClassLoader, CustomRunners customRunners) {
+    suiteRunners = new HashMap<>();
+      customRunners.all().forEach((suite, runner) -> {
+        try {
+          suiteRunners.put(
+              testClassLoader.loadClass(suite),
+              testClassLoader.loadClass(runner)
+          );
+        } catch (ClassNotFoundException e) {
+          e.printStackTrace();
+        }
+      });
+  }
+
+  public Optional<Class<?>> customRunner(Class<?> clazz) {
+    for (Map.Entry<Class<?>, Class<?>> entry : suiteRunners.entrySet()) {
+      if (entry.getKey().isAssignableFrom(clazz)) {
+        return Optional.of(entry.getValue());
+      }
+    }
+    return Optional.empty();
+  }
+
+
+  private class MySuite extends Suite implements Filterable {
+    public MySuite(RunnerBuilder runnerBuilder, Class<?>[] classes) throws InitializationError {
+      super(runnerBuilder, classes);
+    }
+
+    @Override
+    public void filter(Filter filter) throws NoTestsRemainException {
+      for (Runner r : super.getChildren()) {
+        filter.apply(r);
+      }
+    }
+  }
+
+  @Override
+  public Runner getSuite(RunnerBuilder builder, Class<?>[] classes) throws InitializationError {
+    RunnerBuilder runnerBuilder = new RunnerBuilder() {
+      @Override
+      public Runner runnerForClass(Class<?> testClass) throws Throwable {
+        return getRunner(builder, testClass);
+      }
+    };
+    return new MySuite(runnerBuilder, classes);
+  }
+
+  @Override
+  protected Runner getRunner(RunnerBuilder builder, Class<?> testClass) throws Throwable {
+    Optional<Class<?>> runnerClass = customRunner(testClass);
+    if (runnerClass.isPresent()) {
+      Runner runner = (Runner) runnerClass.get().getConstructor(Class.class).newInstance(testClass);
+      return new JUnitRunnerWrapper(runner);
+    } else {
+      return super.getRunner(builder, testClass);
+    }
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitFingerprint.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitFingerprint.java
@@ -1,0 +1,9 @@
+package munit.internal.junitinterface;
+
+public class JUnitFingerprint extends AbstractAnnotatedFingerprint {
+  @Override
+  public String annotationName() { return "org.junit.Test"; }
+
+  @Override
+  public boolean isModule() { return false; }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitFramework.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitFramework.java
@@ -1,0 +1,39 @@
+package munit.internal.junitinterface;
+
+import java.util.Arrays;
+
+import sbt.testing.Fingerprint;
+import sbt.testing.Framework;
+
+
+public class JUnitFramework implements Framework
+{
+  private static Fingerprint[] FINGERPRINTS = new Fingerprint[] {
+      new RunWithFingerprint(),
+      new JUnitFingerprint(),
+      new JUnit3Fingerprint()
+  };
+
+  @Override
+  public String name() { return "JUnit"; }
+
+  @Override
+  public sbt.testing.Fingerprint[] fingerprints() {
+    CustomRunners customRunners = customRunners();
+    if (customRunners.isEmpty()) return FINGERPRINTS;
+    Fingerprint[] result = new Fingerprint[FINGERPRINTS.length + customRunners.runners.size()];
+    System.arraycopy(FINGERPRINTS, 0, result, 0, FINGERPRINTS.length);
+    CustomFingerprint[] customFingerprints = customRunners.runners.toArray(new CustomFingerprint[0]);
+    System.arraycopy(customFingerprints, 0, result, FINGERPRINTS.length, customFingerprints.length);
+    return result;
+  }
+
+  public CustomRunners customRunners() {
+    return CustomRunners.of();
+  }
+
+  @Override
+  public sbt.testing.Runner runner(String[] args, String[] remoteArgs, ClassLoader testClassLoader) {
+    return new JUnitRunner(args, remoteArgs, testClassLoader, customRunners());
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitRunner.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitRunner.java
@@ -1,0 +1,144 @@
+package munit.internal.junitinterface;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.runner.notification.RunListener;
+
+import sbt.testing.Runner;
+import sbt.testing.Task;
+import sbt.testing.TaskDef;
+
+
+final class JUnitRunner implements Runner {
+  private final String[] args;
+  private final String[] remoteArgs;
+  private final RunSettings settings;
+
+  private volatile boolean used = false;
+
+  final ClassLoader testClassLoader;
+  final RunListener runListener;
+  final RunStatistics runStatistics;
+  final CustomRunners customRunners;
+
+  JUnitRunner(String[] args, String[] remoteArgs, ClassLoader testClassLoader, CustomRunners customRunners) {
+
+    this.args = args;
+    this.remoteArgs = remoteArgs;
+    this.testClassLoader = testClassLoader;
+    this.customRunners = customRunners;
+
+    boolean quiet = false, nocolor = false, decodeScalaNames = false,
+        logAssert = true, logExceptionClass = true, useSbtLoggers = false;
+    boolean verbose = false;
+    boolean suppressSystemError = false;
+    RunSettings.Summary summary = RunSettings.Summary.SBT;
+    HashMap<String, String> sysprops = new HashMap<String, String>();
+    ArrayList<String> globPatterns = new ArrayList<String>();
+    Set<String> includeCategories = new HashSet<String>();
+    Set<String> excludeCategories = new HashSet<String>();
+    Set<String> includeTags = new HashSet<String>();
+    Set<String> excludeTags = new HashSet<String>();
+
+    String testFilter = "";
+    String ignoreRunners = "org.junit.runners.Suite";
+    String runListener = null;
+    for(String s : args) {
+      if("-q".equals(s)) quiet = true;
+      else if("-v".equals(s) || "--verbose".equals(s)) verbose = true;
+      else if(s.startsWith("--summary=")) summary = RunSettings.Summary.values()[Integer.parseInt(s.substring(10))];
+      else if("-n".equals(s)) nocolor = true;
+      else if("-s".equals(s)) decodeScalaNames = true;
+      else if("-a".equals(s)) logAssert = true;
+      else if("-c".equals(s)) logExceptionClass = false;
+      else if("+l".equals(s)) useSbtLoggers = true;
+      else if("-l".equals(s)) useSbtLoggers = false;
+      else if(s.startsWith("--tests=")) testFilter = s.substring(8);
+      else if(s.startsWith("--ignore-runners=")) ignoreRunners = s.substring(17);
+      else if(s.startsWith("--run-listener=")) runListener = s.substring(15);
+      else if(s.startsWith("--include-categories=")) includeCategories.addAll(Arrays.asList(s.substring(21).split(",")));
+      else if(s.startsWith("--exclude-categories=")) excludeCategories.addAll(Arrays.asList(s.substring(21).split(",")));
+      else if(s.startsWith("--include-tags=")) includeTags.addAll(Arrays.asList(s.substring("--include-tags=".length()).split(",")));
+      else if(s.startsWith("--exclude-tags=")) excludeTags.addAll(Arrays.asList(s.substring("--exclude-tags=".length()).split(",")));
+      else if(s.startsWith("-D") && s.contains("=")) {
+        int sep = s.indexOf('=');
+        sysprops.put(s.substring(2, sep), s.substring(sep+1));
+      }
+      else if(!s.startsWith("-") && !s.startsWith("+")) globPatterns.add(s);
+    }
+    for(String s : args) {
+      if("+q".equals(s)) quiet = false;
+      else if("+n".equals(s)) nocolor = false;
+      else if("+s".equals(s)) decodeScalaNames = false;
+      else if("+a".equals(s)) logAssert = false;
+      else if("+c".equals(s)) logExceptionClass = true;
+      else if("+l".equals(s)) useSbtLoggers = true;
+      else if("--no-stderr".equals(s)) suppressSystemError = true;
+      else if("--stderr".equals(s)) suppressSystemError = false;
+    }
+    this.settings =
+      new RunSettings(!nocolor, decodeScalaNames, quiet, verbose, useSbtLoggers, summary, logAssert, ignoreRunners, logExceptionClass,
+          suppressSystemError, sysprops, globPatterns, includeCategories, excludeCategories, includeTags, excludeTags,
+        testFilter);
+    this.runListener = createRunListener(runListener);
+    this.runStatistics = new RunStatistics(settings);
+  }
+
+  @Override
+  public Task[] tasks(TaskDef[] taskDefs) {
+    used = true;
+    JUnitComputer computer = new JUnitComputer(testClassLoader, customRunners);
+    int length = taskDefs.length;
+    List<Task> tasks = new ArrayList<>(taskDefs.length);
+    for (int i = 0; i < length; i++) {
+      TaskDef taskDef = taskDefs[i];
+      if (shouldRun(computer, taskDef)) {
+        tasks.add(new JUnitTask(this, settings, taskDef, computer));
+      }
+    }
+    return tasks.toArray(new Task[0]);
+  }
+
+  private boolean shouldRun(JUnitComputer computer, TaskDef taskDef) {
+    try {
+      Class<?> cls = testClassLoader.loadClass(taskDef.fullyQualifiedName());
+      return !computer.customRunner(cls).isPresent() || customRunners.matchesFingerprint(taskDef.fingerprint());
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+  private RunListener createRunListener(String runListenerClassName) {
+    if(runListenerClassName != null) {
+      try {
+        return (RunListener) testClassLoader.loadClass(runListenerClassName).newInstance();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    } else return null;
+  }
+
+  @Override
+  public String done() {
+    // Can't simply return the summary due to https://github.com/sbt/sbt/issues/3510
+    if(!used) return "";
+    String stats = runStatistics.createSummary();
+    if(stats.isEmpty()) return stats;
+    System.out.println(stats);
+    return " ";
+  }
+
+  @Override
+  public String[] remoteArgs() {
+    return remoteArgs;
+  }
+
+  @Override
+  public String[] args() {
+    return args;
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitRunnerWrapper.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitRunnerWrapper.java
@@ -1,0 +1,31 @@
+package munit.internal.junitinterface;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.Filterable;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runner.notification.RunNotifier;
+
+class JUnitRunnerWrapper extends Runner implements Filterable {
+    private final Runner delegate;
+
+    JUnitRunnerWrapper(Runner delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Description getDescription() {
+      return delegate.getDescription();
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+      delegate.run(notifier);
+    }
+
+    @Override
+    public void filter(Filter filter) throws NoTestsRemainException {
+      filter.apply(delegate);
+    }
+  }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitTask.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitTask.java
@@ -1,0 +1,130 @@
+package munit.internal.junitinterface;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.experimental.categories.Categories;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Request;
+import org.junit.runner.RunWith;
+
+import junit.framework.TestCase;
+import sbt.testing.EventHandler;
+import sbt.testing.Fingerprint;
+import sbt.testing.Logger;
+import sbt.testing.Task;
+import sbt.testing.TaskDef;
+
+final class JUnitTask implements Task {
+  private static final Fingerprint JUNIT_FP = new JUnitFingerprint();
+
+  private final JUnitRunner runner;
+  private final RunSettings settings;
+  private final TaskDef taskDef;
+  private final JUnitComputer computer;
+
+  public JUnitTask(JUnitRunner runner, RunSettings settings, TaskDef taskDef, JUnitComputer computer) {
+    this.runner = runner;
+    this.settings = settings;
+    this.taskDef = taskDef;
+    this.computer = computer;
+  }
+
+  @Override
+  public String[] tags() {
+    return new String[0];  // no tags yet
+  }
+
+  @Override
+  public TaskDef taskDef() { return taskDef; }
+
+  @Override
+  public Task[] execute(EventHandler eventHandler, Logger[] loggers) {
+    Fingerprint fingerprint = taskDef.fingerprint();
+    String testClassName = taskDef.fullyQualifiedName();
+    Description taskDescription = Description.createSuiteDescription(testClassName);
+    RichLogger logger = new RichLogger(loggers, settings, testClassName, runner);
+    EventDispatcher ed = new EventDispatcher(logger, eventHandler, settings, fingerprint, taskDescription, runner.runStatistics);
+    JUnitCore ju = new JUnitCore();
+    ju.addListener(ed);
+    if (runner.runListener != null) ju.addListener(runner.runListener);
+
+    Map<String, Object> oldprops = settings.overrideSystemProperties();
+    PrintStream oldSystemError = System.err;
+    try {
+      suppressSystemError();
+      try {
+        Class<?> cl = runner.testClassLoader.loadClass(testClassName);
+        boolean isRun = shouldRun(fingerprint, cl, settings);
+        if(isRun) {
+          Request request = Request.classes(computer, cl);
+          if(settings.globPatterns.size() > 0) {
+            request = new SilentFilterRequest(request, new GlobFilter(settings, settings.globPatterns));
+          }
+          if(settings.testFilter.length() > 0) {
+            request = new SilentFilterRequest(request, new TestFilter(settings.testFilter, ed));
+          }
+          if(!settings.includeCategories.isEmpty() || !settings.excludeCategories.isEmpty()) {
+            request = new SilentFilterRequest(request,
+                Categories.CategoryFilter.categoryFilter(true, loadClasses(runner.testClassLoader, settings.includeCategories), true,
+                    loadClasses(runner.testClassLoader, settings.excludeCategories)));
+          }
+          if(!settings.includeTags.isEmpty() || !settings.excludeTags.isEmpty()) {
+            request = new SilentFilterRequest(request, new TagFilter(settings.includeTags, settings.excludeTags));
+          }
+          ju.run(request);
+        }
+      } catch(Exception ex) {
+        ed.testExecutionFailed(testClassName, ex);
+      }
+    } finally {
+      settings.restoreSystemProperties(oldprops);
+      System.setErr(oldSystemError);
+    }
+    return new Task[0]; // junit tests do not nest
+  }
+
+
+  private static final PrintStream EMPTY_PRINTSTREAM = new PrintStream(new OutputStream() {
+    @Override
+    public void write(int b) {}
+  });
+  private void suppressSystemError() {
+    if (settings.suppressSystemError) {
+      System.setErr(EMPTY_PRINTSTREAM);
+    }
+  }
+
+
+  private boolean shouldRun(Fingerprint fingerprint, Class<?> clazz, RunSettings settings) {
+    if(JUNIT_FP.equals(fingerprint)) {
+      // Ignore classes which are matched by the other fingerprints
+      if(TestCase.class.isAssignableFrom(clazz)) {
+        return false;
+      }
+      for(Annotation a : clazz.getDeclaredAnnotations()) {
+        if(a.annotationType().equals(RunWith.class)) return false;
+      }
+      return true;
+    } else {
+      RunWith rw = clazz.getAnnotation(RunWith.class);
+      if(rw != null) {
+        return !settings.ignoreRunner(rw.value().getName());
+      }
+      else return true;
+    }
+  }
+
+  private static Set<Class<?>> loadClasses(ClassLoader classLoader, Set<String> classNames) throws ClassNotFoundException {
+    Set<Class<?>> classes = new HashSet<Class<?>>();
+    for(String className : classNames) {
+      classes.add(classLoader.loadClass(className));
+    }
+    return classes;
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/OutputCapture.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/OutputCapture.java
@@ -1,0 +1,73 @@
+package munit.internal.junitinterface;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+
+final class OutputCapture
+{
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalScalaOut = getScalaOut();
+  private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+  private final PrintStream prBuffer = new PrintStream(buffer, true);
+  private final boolean scalaOutSet;
+
+  private OutputCapture()
+  {
+    //System.err.println("***** Replacing "+System.out+" with buffer "+prBuffer);
+    System.out.flush();
+    System.setOut(prBuffer);
+    scalaOutSet = setScalaOut(prBuffer);
+  }
+
+  static OutputCapture start() { return new OutputCapture(); }
+
+  void stop()
+  {
+    //System.err.println("***** Restoring "+originalOut);
+    System.out.flush();
+    System.setOut(originalOut);
+    if(scalaOutSet) setScalaOut(originalScalaOut);
+  }
+
+  void replay() throws IOException
+  {
+    //System.err.println("***** Replaying to "+System.out);
+    System.out.write(buffer.toByteArray());
+    System.out.flush();
+  }
+
+  private static PrintStream getScalaOut()
+  {
+    try
+    {
+      Class<?> cl = Class.forName("scala.Console");
+      Method m = cl.getMethod("out");
+      return (PrintStream)m.invoke(null);
+    }
+    catch(Throwable t)
+    {
+      //System.err.println("Error getting Scala console:");
+      //t.printStackTrace(System.err);
+      return null;
+    }
+  }
+
+  private static boolean setScalaOut(PrintStream p)
+  {
+    try
+    {
+      Class<?> cl = Class.forName("scala.Console");
+      Method m = cl.getMethod("setOut", PrintStream.class);
+      m.invoke(null, p);
+      return true;
+    }
+    catch(Throwable t)
+    {
+      //System.err.println("Error setting Scala console:");
+      //t.printStackTrace(System.err);
+      return false;
+    }
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/PantsFramework.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/PantsFramework.java
@@ -1,0 +1,41 @@
+package munit.internal.junitinterface;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+import sbt.testing.Fingerprint;
+
+public class PantsFramework extends JUnitFramework {
+
+  private static final CustomFingerprint scalatestFingerprint = CustomFingerprint.of(
+      "org.scalatest.Suite",
+      "org.scalatest.junit.JUnitRunner"
+  );
+
+  private static final Fingerprint[] FINGERPRINTS = new Fingerprint[] {
+      new RunWithFingerprint(),
+      new JUnitFingerprint(),
+      new JUnit3Fingerprint(),
+      scalatestFingerprint
+  };
+
+  @Override
+  public Fingerprint[] fingerprints() {
+    return FINGERPRINTS;
+  }
+
+  @Override
+  public CustomRunners customRunners() {
+    return CustomRunners.of(scalatestFingerprint);
+  }
+
+  @Override
+  public sbt.testing.Runner runner(String[] args, String[] remoteArgs, ClassLoader testClassLoader) {
+    String[] newArgs = new String[args.length + 1];
+    // NOTE(olafur): by default, stderr is not printed when running tests. Users can still enable
+    // stderr by passing in the "--stderr" flag.
+    newArgs[0] = "--no-stderr";
+    System.arraycopy(args, 0, newArgs, 1, args.length);
+    return super.runner(newArgs, remoteArgs, testClassLoader);
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/RichLogger.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RichLogger.java
@@ -1,0 +1,207 @@
+package munit.internal.junitinterface;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.concurrent.ConcurrentHashMap;
+
+import sbt.testing.Logger;
+import static munit.internal.junitinterface.Ansi.*;
+
+
+final class RichLogger
+{
+  private final Logger[] loggers;
+  private final RunSettings settings;
+  private final JUnitRunner runner;
+  /* The top element is the test class of the currently executing test */
+  private final Stack<String> currentTestClassName = new Stack<String>();
+  private final Map<String, Boolean> highlightedCache = new HashMap<>();
+
+  RichLogger(Logger[] loggers, RunSettings settings, String testClassName, JUnitRunner runner)
+  {
+    this.loggers = loggers;
+    this.settings = settings;
+    this.runner = runner;
+    currentTestClassName.push(testClassName);
+  }
+
+  void pushCurrentTestClassName(String s) { currentTestClassName.push(s); }
+
+  void popCurrentTestClassName()
+  {
+    if(currentTestClassName.size() > 1) currentTestClassName.pop();
+  }
+
+  void debug(String s)
+  {
+    // Disabled by default because debug logging is noisy and enabled by default in sbt.
+    if (settings.useSbtLoggers) {
+      for(Logger l : loggers)
+      if(settings.color && l.ansiCodesSupported()) l.debug(s);
+      else l.debug(filterAnsi(s));
+    }
+  }
+
+  void error(String s)
+  {
+    if (settings.useSbtLoggers) {
+      for (Logger l : loggers)
+        if (settings.color && l.ansiCodesSupported()) l.error(s);
+        else l.error(filterAnsi(s));
+    } else {
+      System.out.println(s);
+    }
+  }
+
+  void error(String s, Throwable t)
+  {
+    error(s);
+    if(t != null && (settings.logAssert || !(t instanceof AssertionError))) logStackTrace(t);
+  }
+
+  void info(String s)
+  {
+    if (settings.useSbtLoggers) {
+      for (Logger l : loggers)
+        if (settings.color && l.ansiCodesSupported()) l.info(s);
+        else l.info(filterAnsi(s));
+    } else {
+      System.out.println(s);
+    }
+  }
+
+  void warn(String s)
+  {
+    if (settings.useSbtLoggers) {
+      for (Logger l : loggers)
+        if (settings.color && l.ansiCodesSupported()) l.warn(s);
+        else l.warn(filterAnsi(s));
+    } else {
+      System.out.println(s);
+    }
+  }
+
+  void warn(String s, Throwable t)
+  {
+    warn(s);
+    if(t != null && (settings.logAssert || !(t instanceof AssertionError))) logStackTrace(t);
+  }
+
+  private void logStackTrace(Throwable t)
+  {
+    StackTraceElement[] trace = t.getStackTrace();
+    String testClassName = currentTestClassName.peek();
+    String testFileName = settings.color ? findTestFileName(trace, testClassName) : null;
+    logStackTracePart(trace, trace.length-1, 0, t, testClassName, testFileName);
+  }
+
+  private void logStackTracePart(StackTraceElement[] trace, int m, int framesInCommon, Throwable t, String testClassName, String testFileName)
+  {
+    final int m0 = m;
+    int top = 0;
+    for(int i=top; i<=m; i++)
+    {
+      if(trace[i].toString().startsWith("org.junit.") ||
+          trace[i].toString().startsWith("org.hamcrest.") ||
+          trace[i].toString().startsWith("org.scalatest."))
+      {
+        if(i == top) top++;
+        else
+        {
+          m = i-1;
+          while(m > top)
+          {
+            String s = trace[m].toString();
+            if(!s.startsWith("java.lang.reflect.") && !s.startsWith("sun.reflect.")) break;
+            m--;
+          }
+          break;
+        }
+      }
+    }
+    for(int i=top; i<=m; i++) {
+      if (!trace[i].getClassName().startsWith("scala.runtime."))
+        error(stackTraceElementToString(trace[i], testClassName, testFileName));
+    }
+    if(m0 != m)
+    {
+      // skip junit-related frames
+      error("    ...");
+    }
+    else if(framesInCommon != 0)
+    {
+      // skip frames that were in the previous trace too
+      error("    ... " + framesInCommon + " more");
+    }
+    logStackTraceAsCause(trace, t.getCause(), testClassName, testFileName);
+  }
+
+  private void logStackTraceAsCause(StackTraceElement[] causedTrace, Throwable t, String testClassName, String testFileName)
+  {
+    if(t == null) return;
+    StackTraceElement[] trace = t.getStackTrace();
+    int m = trace.length - 1, n = causedTrace.length - 1;
+    while(m >= 0 && n >= 0 && trace[m].equals(causedTrace[n]))
+    {
+      m--;
+      n--;
+    }
+    error("Caused by: " + t);
+    logStackTracePart(trace, m, trace.length-1-m, t, testClassName, testFileName);
+  }
+
+  private String findTestFileName(StackTraceElement[] trace, String testClassName)
+  {
+    for(StackTraceElement e : trace)
+    {
+      String cln = e.getClassName();
+      if(testClassName.equals(cln)) return e.getFileName();
+    }
+    return null;
+  }
+
+  private boolean isHighlightedCached(String className) {
+    return highlightedCache.computeIfAbsent(className, name -> isHighlighted(name));
+  }
+
+  private boolean isHighlighted(String className) {
+    try {
+      int dot = className.lastIndexOf('.');
+      String classfile = className.substring(0, dot + 1).replace('.','/');
+      URL resource = runner.testClassLoader.getResource(classfile);
+      return resource.getProtocol().equals("file");
+    } catch (Exception ex) {
+      return false;
+    }
+  }
+
+  private String stackTraceElementToString(StackTraceElement e, String testClassName, String testFileName)
+  {
+    boolean highlight = settings.color && (
+        testClassName.equals(e.getClassName()) ||
+        (testFileName != null && testFileName.equals(e.getFileName())) ||
+        isHighlightedCached(e.getClassName())
+      );
+    String color = highlight ? BOLD : FAINT;
+    StringBuilder b = new StringBuilder();
+    b.append(c("    at ", color));
+    b.append(c(settings.decodeName(e.getClassName() + '.' + e.getMethodName()) , color));
+    b.append(c("(", color));
+
+    if(e.isNativeMethod()) b.append(c("Native Method", color));
+    else if(e.getFileName() == null) b.append(c("Unknown Source", color));
+    else
+    {
+      b.append(c(e.getFileName(), color));
+      if(e.getLineNumber() >= 0)
+        b.append(':').append(c(String.valueOf(e.getLineNumber()), color));
+    }
+    return b.append(c(")", color)).toString();
+  }
+
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
@@ -1,0 +1,211 @@
+package munit.internal.junitinterface;
+
+import static munit.internal.junitinterface.Ansi.ENAME1;
+import static munit.internal.junitinterface.Ansi.ENAME2;
+import static munit.internal.junitinterface.Ansi.ENAME3;
+import static munit.internal.junitinterface.Ansi.ERRMSG;
+import static munit.internal.junitinterface.Ansi.FAILURE1;
+import static munit.internal.junitinterface.Ansi.FAILURE2;
+import static munit.internal.junitinterface.Ansi.NNAME1;
+import static munit.internal.junitinterface.Ansi.NNAME2;
+import static munit.internal.junitinterface.Ansi.NNAME3;
+import static munit.internal.junitinterface.Ansi.SKIPPED;
+import static munit.internal.junitinterface.Ansi.SUCCESS1;
+import static munit.internal.junitinterface.Ansi.SUCCESS2;
+import static munit.internal.junitinterface.Ansi.c;
+
+import java.lang.reflect.Method;
+import java.util.*;
+
+import org.junit.runner.Description;
+
+import sbt.testing.Status;
+
+class RunSettings {
+  private static final Object NULL = new Object();
+
+  final boolean color;
+  final boolean quiet;
+  final boolean logAssert;
+  final boolean logExceptionClass;
+  final Set<String> includeTags, excludeTags;
+  final boolean useSbtLoggers;
+  final boolean verbose;
+  final boolean suppressSystemError;
+  final Summary summary;
+  final ArrayList<String> globPatterns;
+  final Set<String> includeCategories, excludeCategories;
+  final String testFilter;
+
+  private final boolean decodeScalaNames;
+  private final HashMap<String, String> sysprops;
+  private final HashSet<String> ignoreRunners = new HashSet<String>();
+
+  RunSettings(boolean color, boolean decodeScalaNames, boolean quiet,
+              boolean verbose, boolean useSbtLoggers, Summary summary, boolean logAssert, String ignoreRunners,
+              boolean logExceptionClass,
+              boolean suppressSystemError, HashMap<String, String> sysprops,
+              ArrayList<String> globPatterns,
+              Set<String> includeCategories, Set<String> excludeCategories,
+              Set<String> includeTags, Set<String> excludeTags,
+              String testFilter) {
+    this.color = color;
+    this.decodeScalaNames = decodeScalaNames;
+    this.quiet = quiet;
+    this.verbose = verbose;
+    this.summary = summary;
+    this.logAssert = logAssert;
+    this.logExceptionClass = logExceptionClass;
+    this.suppressSystemError = suppressSystemError;
+    this.includeTags = includeTags;
+    this.excludeTags = excludeTags;
+    for(String s : ignoreRunners.split(","))
+      this.ignoreRunners.add(s.trim());
+    this.sysprops = sysprops;
+    this.globPatterns = globPatterns;
+    this.includeCategories = includeCategories;
+    this.excludeCategories = excludeCategories;
+    this.testFilter = testFilter;
+    this.useSbtLoggers = useSbtLoggers;
+  }
+
+  String decodeName(String name) {
+    return decodeScalaNames ? decodeScalaName(name) : name;
+  }
+
+  private static String decodeScalaName(String name) {
+    try {
+      Class<?> cl = Class.forName("scala.reflect.NameTransformer");
+      Method m = cl.getMethod("decode", String.class);
+      String decoded = (String)m.invoke(null, name);
+      return decoded == null ? name : decoded;
+    } catch(Throwable t) {
+      //System.err.println("Error decoding Scala name:");
+      //t.printStackTrace(System.err);
+      return name;
+    }
+  }
+
+  String buildInfoName(Description desc) {
+    return buildColoredName(desc, NNAME1, NNAME2, NNAME3);
+  }
+
+  String buildInfoName(Description desc, Status status) {
+    switch (status) {
+      case Success:
+        return buildSuccessName(desc);
+      case Ignored:
+      case Skipped:
+        return buildSkippedName(desc);
+      default:
+        return buildInfoName(desc);
+    }
+  }
+
+  String buildErrorName(Description desc) {
+    return buildColoredName(desc, ENAME1, ENAME2, ENAME3);
+  }
+
+  String buildErrorName(Description desc, Status status) {
+    switch (status) {
+      case Failure:
+        return buildColoredName(desc, FAILURE1, FAILURE2, FAILURE2);
+      case Skipped:
+      case Ignored:
+        return buildSkippedName(desc);
+      default:
+        return buildErrorName(desc);
+    }
+  }
+
+  String buildSuccessName(Description desc) {
+    return buildColoredName(desc, SUCCESS1, SUCCESS2, SUCCESS2);
+  }
+
+  String buildSkippedName(Description desc) {
+    return buildColoredName(desc, SKIPPED, SKIPPED, SKIPPED);
+  }
+
+  String buildPlainName(Description desc) {
+    return buildColoredName(desc, null, null, null);
+  }
+
+  String buildTestResult(Status status) {
+    switch (status) {
+        case Success:
+          return c("+ ", SUCCESS1);
+        case Ignored:
+          return c("==> i ", SKIPPED);
+        case Skipped:
+          return c("==> s ", SKIPPED);
+        default:
+          return c("==> X ", ERRMSG);
+      }
+  }
+
+  String buildColoredMessage(Throwable t, String c1) {
+    if(t == null) return "null";
+    if(!logExceptionClass || (!logAssert && (t instanceof AssertionError)))  return t.getMessage();
+    StringBuilder b = new StringBuilder();
+    b.append(decodeName(t.getClass().getName()));
+    b.append(": ").append(t.getMessage());
+    return b.toString();
+  }
+
+  String buildErrorMessage(Throwable t) {
+    return buildColoredMessage(t, ENAME2);
+  }
+
+  private String buildColoredName(Description desc, String c1, String c2, String c3) {
+    StringBuilder b = new StringBuilder();
+    String cn = decodeName(desc.getClassName());
+    b.append(c(cn, c1));
+    String m = desc.getMethodName();
+    if(m != null) {
+      b.append('.');
+      int mpos1 = m.lastIndexOf('[');
+      int mpos2 = m.lastIndexOf(']');
+      if(mpos1 == -1 || mpos2 < mpos1) b.append(c(decodeName(m), c2));
+      else {
+        b.append(c(decodeName(m.substring(0, mpos1)), c2));
+        b.append('[');
+        b.append(c(m.substring(mpos1+1, mpos2), c3));
+        b.append(']');
+      }
+    }
+
+    return b.toString();
+  }
+
+  boolean ignoreRunner(String cln) { return ignoreRunners.contains(cln); }
+
+  Map<String, Object> overrideSystemProperties() {
+    HashMap<String, Object> oldprops = new HashMap<String, Object>();
+    synchronized(System.getProperties()) {
+      for(Map.Entry<String, String> me : sysprops.entrySet()) {
+        String old = System.getProperty(me.getKey());
+        oldprops.put(me.getKey(), old == null ? NULL : old);
+      }
+      for(Map.Entry<String, String> me : sysprops.entrySet()) {
+        System.setProperty(me.getKey(), me.getValue());
+      }
+    }
+    return oldprops;
+  }
+
+  void restoreSystemProperties(Map<String, Object> oldprops) {
+    synchronized(System.getProperties()) {
+      for(Map.Entry<String, Object> me : oldprops.entrySet()) {
+        if(me.getValue() == NULL) {
+          System.clearProperty(me.getKey());
+        } else {
+          System.setProperty(me.getKey(), (String)me.getValue());
+        }
+      }
+    }
+  }
+
+  static enum Summary {
+    SBT, ONE_LINE, LIST_FAILED
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/RunStatistics.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RunStatistics.java
@@ -1,0 +1,62 @@
+package munit.internal.junitinterface;
+
+import sbt.testing.Status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class RunStatistics {
+  private final RunSettings settings;
+
+  private int failedCount, ignoredCount, otherCount;
+  private final ArrayList<String> failedNames = new ArrayList<>();
+  private final ArrayList<String> otherNames = new ArrayList<>();
+  private volatile long accumulatedTime;
+
+  RunStatistics(RunSettings settings) {
+    this.settings = settings;
+  }
+
+  void addTime(long t) { accumulatedTime += t; }
+
+  synchronized void captureStats(AbstractEvent e) {
+    Status s = e.status();
+    if(s == Status.Error || s == Status.Failure) {
+      failedCount++;
+      failedNames.add(e.fullyQualifiedName());
+    }
+    else {
+      if(s == Status.Ignored) ignoredCount++;
+      else otherCount++;
+      otherNames.add(e.fullyQualifiedName());
+    }
+  }
+
+  private String summaryLine() {
+    return (failedCount == 0 ? "All tests passed: " : "Some tests failed: ") +
+      failedCount+" failed, "+ignoredCount+" ignored, "+(failedCount+ignoredCount+otherCount)+" total, "+
+      (accumulatedTime/1000.0)+"s";
+  }
+
+  private static String mkString(List<String> l) {
+    StringBuilder b = new StringBuilder();
+    for(String s : l) {
+      if(b.length() != 0) b.append(", ");
+      b.append(s);
+    }
+    return b.toString();
+  }
+
+  synchronized String createSummary() {
+    switch(settings.summary) {
+      case LIST_FAILED:
+        return failedNames.isEmpty() ?
+          summaryLine() :
+          (summaryLine() + "\n- Failed tests: " + mkString(failedNames));
+      case ONE_LINE:
+        return summaryLine();
+      default:
+        return "";
+    }
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/RunWithFingerprint.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RunWithFingerprint.java
@@ -1,0 +1,9 @@
+package munit.internal.junitinterface;
+
+public class RunWithFingerprint extends AbstractAnnotatedFingerprint {
+  @Override
+  public String annotationName() { return "org.junit.runner.RunWith"; }
+
+  @Override
+  public boolean isModule() { return false; }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/SilentFilterRequest.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/SilentFilterRequest.java
@@ -1,0 +1,30 @@
+package munit.internal.junitinterface;
+
+import org.junit.runner.Request;
+import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.NoTestsRemainException;
+
+/**
+ * A filtered request which ignores NoTestsRemainExceptions.
+ */
+final class SilentFilterRequest extends Request {
+  private final Request request;
+  private final Filter filter;
+
+  public SilentFilterRequest(Request request, Filter filter) {
+    this.request = request;
+    this.filter = filter;
+  }
+
+  @Override 
+  public Runner getRunner() {
+    Runner runner = request.getRunner();
+    try {
+      filter.apply(runner);
+      return runner;
+    } catch (NoTestsRemainException e) {
+      return new EmptyRunner(runner.getDescription());
+    }
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/Tag.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/Tag.java
@@ -1,0 +1,5 @@
+package munit.internal.junitinterface;
+
+public interface Tag {
+    String value();
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/TagFilter.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/TagFilter.java
@@ -1,0 +1,46 @@
+package munit.internal.junitinterface;
+
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+public class TagFilter extends Filter {
+    final Set<String> includeTags, excludeTags;
+
+    public TagFilter(Set<String> includeTags, Set<String> excludeTags) {
+        this.includeTags = includeTags;
+        this.excludeTags = excludeTags;
+    }
+
+    @Override
+    public boolean shouldRun(Description description) {
+        if (includeTags.isEmpty() && excludeTags.isEmpty()) return true;
+        boolean isIncluded = includeTags.isEmpty();
+        for (Annotation annotation : description.getAnnotations()) {
+            if (annotation instanceof Tag) {
+                Tag tag = (Tag) annotation;
+                isIncluded = isIncluded || includeTags.contains(tag.value());
+                boolean isExcluded = excludeTags.contains(tag.value());
+                if (isExcluded) {
+                    return false;
+                }
+            }
+        }
+        return isIncluded;
+    }
+
+    @Override
+    public String toString() {
+        return "TagFilter{" +
+                "includeTags=" + includeTags +
+                ", excludeTags=" + excludeTags +
+                '}';
+    }
+
+    @Override
+    public String describe() {
+        return toString();
+    }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/TaskDefFilter.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/TaskDefFilter.java
@@ -1,0 +1,13 @@
+package munit.internal.junitinterface;
+
+import sbt.testing.TaskDef;
+
+public class TaskDefFilter {
+
+  public TaskDefFilter(ClassLoader testClassLoader) {
+  }
+
+  public boolean shouldRun(TaskDef taskDef) {
+    return true;
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/TestFilter.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/TestFilter.java
@@ -1,0 +1,51 @@
+// Mostly copied from http://stackoverflow.com/questions/1230706/running-a-subset-of-junit-test-methods/1236782#1236782
+package munit.internal.junitinterface;
+
+import java.util.HashSet;
+import java.util.regex.Pattern;
+
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+
+public final class TestFilter extends Filter
+{
+  private static final String DELIMITER = "\\,";
+
+  private final HashSet<String> ignored = new HashSet<String>();
+  private final String[] testPatterns;
+  private final EventDispatcher ed;
+
+  public TestFilter(String testFilter, EventDispatcher ed)
+  {
+    this.ed = ed;
+    this.testPatterns = testFilter.split(DELIMITER);
+  }
+
+  @Override
+  public String describe()
+  {
+    return "Filters out all tests not explicitly named in the '-tests=' option.";
+  }
+
+  @Override
+  public boolean shouldRun(Description d)
+  {
+    String displayName = d.getDisplayName();
+
+    // We get asked both if we should run the class/suite, as well as the individual tests
+    // So let the suite always run, so we can evaluate the individual test cases
+    if(displayName.indexOf('(') == -1) return true;
+    String testName = displayName.substring(0, displayName.indexOf('('));
+
+    // JUnit calls this multiple times per test and we don't want to print a new "test ignored"
+    // message each time
+    if(ignored.contains(testName)) return false;
+
+    for(String p : testPatterns)
+      if(Pattern.matches(p, testName)) return true;
+
+    ignored.add(testName);
+    ed.testIgnored(d);
+    return false;
+  }
+}

--- a/junit-interface/src/main/ls/0.8.json
+++ b/junit-interface/src/main/ls/0.8.json
@@ -1,0 +1,23 @@
+{
+ "organization":"com.novocode",
+ "name":"junit-interface",
+ "version":"0.8",
+ "description":"An implementation of sbt's test interface for JUnit 4. This allows you to run JUnit tests from sbt.",
+ "site":"https://github.com/szeiger/junit-interface",
+ "tags":["junit", "sbt"],
+ "licenses": [{
+   "name": "BSD",
+   "url": "https://github.com/szeiger/junit-interface/blob/635f723f1f6a8bc4f77ff95afa12ede2070e8e66/LICENSE.txt"
+ }],
+ "resolvers": ["http://scala-tools.org/repo-releases"],
+ "dependencies": [{
+   "organization":"junit",
+   "name": "junit",
+   "version": "4.8.2"
+ },{
+   "organization":"org.scala-tools.testing",
+   "name": "test-interface",
+   "version": "0.5"
+ }],
+ "sbt": true
+}

--- a/munit/jvm/src/main/scala/munit/Framework.scala
+++ b/munit/jvm/src/main/scala/munit/Framework.scala
@@ -2,11 +2,11 @@ package munit
 
 import sbt.testing.Fingerprint
 
-import com.geirsson.junit.CustomFingerprint
-import com.geirsson.junit.CustomRunners
+import munit.internal.junitinterface.CustomFingerprint
+import munit.internal.junitinterface.CustomRunners
 import sbt.testing.SubclassFingerprint
 
-class Framework extends com.geirsson.junit.JUnitFramework {
+class Framework extends munit.internal.junitinterface.JUnitFramework {
   val munitFingerprint: CustomFingerprint = CustomFingerprint.of(
     "munit.Suite",
     "munit.MUnitRunner"

--- a/munit/non-jvm/src/main/scala/com/geirsson/junit/Tag.scala
+++ b/munit/non-jvm/src/main/scala/com/geirsson/junit/Tag.scala
@@ -1,5 +1,0 @@
-package com.geirsson.junit
-
-trait Tag {
-  def value(): String
-}

--- a/munit/non-jvm/src/main/scala/munit/Framework.scala
+++ b/munit/non-jvm/src/main/scala/munit/Framework.scala
@@ -1,6 +1,8 @@
 package munit
 
-import com.geirsson.junit.{CustomFingerprint, CustomRunners, JUnitFramework}
+import munit.internal.junitinterface.CustomFingerprint
+import munit.internal.junitinterface.CustomRunners
+import munit.internal.junitinterface.JUnitFramework
 
 class Framework extends JUnitFramework {
   override val name = "munit"

--- a/munit/non-jvm/src/main/scala/munit/internal/MUnitFingerprint.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/MUnitFingerprint.scala
@@ -1,6 +1,6 @@
 package munit.internal
 
-import com.geirsson.junit.CustomFingerprint
+import munit.internal.junitinterface.CustomFingerprint
 
 class MUnitFingerprint(isModule: Boolean)
     extends CustomFingerprint("munit.Suite", isModule)

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/CustomFingerprint.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/CustomFingerprint.scala
@@ -1,4 +1,4 @@
-package com.geirsson.junit
+package munit.internal.junitinterface
 
 import sbt.testing.SubclassFingerprint
 

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/CustomRunners.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/CustomRunners.scala
@@ -1,4 +1,4 @@
-package com.geirsson.junit
+package munit.internal.junitinterface
 
 import sbt.testing.{Fingerprint, SubclassFingerprint}
 

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/IncludeFilter.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/IncludeFilter.scala
@@ -1,4 +1,4 @@
-package com.geirsson.junit
+package munit.internal.junitinterface
 
 import org.junit.runner.Description
 import org.junit.runner.manipulation.Filter

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitEvent.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitEvent.scala
@@ -2,7 +2,7 @@
  * Adapted from https://github.com/scala-js/scala-js, see NOTICE.md.
  */
 
-package com.geirsson.junit
+package munit.internal.junitinterface
 
 import sbt.testing._
 

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitFramework.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitFramework.scala
@@ -2,7 +2,7 @@
  * Adapted from https://github.com/scala-js/scala-js, see NOTICE.md.
  */
 
-package com.geirsson.junit
+package munit.internal.junitinterface
 
 import sbt.testing._
 

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitReporter.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitReporter.scala
@@ -2,7 +2,7 @@
  * Adapted from https://github.com/scala-js/scala-js, see NOTICE.md.
  */
 
-package com.geirsson.junit
+package munit.internal.junitinterface
 
 import munit.internal.console.AnsiColors
 import sbt.testing._

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitRunner.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitRunner.scala
@@ -2,7 +2,7 @@
  * Adapted from https://github.com/scala-js/scala-js, see NOTICE.md.
  */
 
-package com.geirsson.junit
+package munit.internal.junitinterface
 
 import sbt.testing._
 import munit.internal.PlatformCompat

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitTask.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitTask.scala
@@ -2,7 +2,7 @@
  * Adapted from https://github.com/scala-js/scala-js, see NOTICE.md.
  */
 
-package com.geirsson.junit
+package munit.internal.junitinterface
 
 import munit.internal.PlatformCompat
 import org.junit.runner.notification.RunNotifier

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/MUnitRunNotifier.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/MUnitRunNotifier.scala
@@ -1,4 +1,4 @@
-package com.geirsson.junit
+package munit.internal.junitinterface
 
 import org.junit.runner.{Description, notification}
 import org.junit.runner.notification.RunNotifier

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/RunSettings.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/RunSettings.scala
@@ -2,7 +2,7 @@
  * Adapted from https://github.com/scala-js/scala-js, see NOTICE.md.
  */
 
-package com.geirsson.junit
+package munit.internal.junitinterface
 
 import scala.util.Try
 

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/Tag.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/Tag.scala
@@ -1,0 +1,5 @@
+package munit.internal.junitinterface
+
+trait Tag {
+  def value(): String
+}

--- a/munit/shared/src/main/scala/munit/Tag.scala
+++ b/munit/shared/src/main/scala/munit/Tag.scala
@@ -4,7 +4,7 @@ import java.lang.annotation.Annotation
 import scala.runtime.Statics
 
 class Tag(val value: String)
-    extends com.geirsson.junit.Tag
+    extends munit.internal.junitinterface.Tag
     with Annotation
     with Serializable {
   // Not a case class so that it possible to override these.


### PR DESCRIPTION
Previously, the JUnit sbt interface was maintained in a fork under my
personal GitHub account. This was annoying when fixing issues like:

* https://github.com/scalameta/munit/issues/50 change formatting of test results
* https://github.com/scalameta/munit/issues/51 uncaught exception in
  junit-interface causing failing test case to be reported as success.

Now, the junit-interface codebase has been folded into the MUnit repo so
that it can evolve alongside MUnit.