### PR TITLE
Fix bug where test cases got reported as duplicates in IntelliJ.

### DIFF
--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -62,7 +62,10 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
     )
   }
 
-  override def getDescription(): Description = {
+  // NOTE(olafur): this method is a lazy val to avoid repeated computations.
+  // This method may get multiple times by clients such as IntelliJ, see
+  // https://github.com/scalameta/munit/issues/47
+  override lazy val getDescription: Description = {
     try {
       val suiteTests = StackTraces.dropOutside(munitTests)
       suiteTests.foreach { test =>


### PR DESCRIPTION
Fixes #47. Previously, the `getDescription` method performed
side-effects adding all the test cases as children to the suite
description. When a client such as IntelliJ called `getDescription`
repeated times then it appeared as if the same test started multiple
times in the IntelliJ UI.