### PR TITLE
Add method overload to `test` helper for easier readability.

### DIFF
--- a/munit/shared/src/main/scala/munit/FunSuite.scala
+++ b/munit/shared/src/main/scala/munit/FunSuite.scala
@@ -71,6 +71,12 @@ abstract class FunSuite
   def munitNewTest(test: Test): Test =
     test
 
+  def test(name: String)(
+      body: => Any
+  )(implicit loc: Location): Unit = {
+    test(new TestOptions(name, Set.empty, loc))(body)
+  }
+
   def test(options: TestOptions)(
       body: => Any
   )(implicit loc: Location): Unit = {


### PR DESCRIPTION
This overload is not necessary since we already have an implicit
conversion in scope. However, by adding the overload users won't have to
understand implicit conversions to use MUnit in the common case.