### PR TITLE
 Add failSuite() helper to abort the entire test suite

### DIFF
--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -160,6 +160,16 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
     )
   }
 
+  def failSuite(
+      message: String,
+      clues: Clues = new Clues(Nil)
+  )(implicit loc: Location): Nothing = {
+    throw new FailSuiteException(
+      munitFilterAnsi(munitLines.formatLine(loc, message, clues)),
+      loc
+    )
+  }
+
   private val munitCapturedClues: mutable.ListBuffer[Clue[_]] =
     mutable.ListBuffer.empty
   def munitCaptureClues[T](thunk: => T): (T, Clues) =

--- a/munit/shared/src/main/scala/munit/FailSuiteException.scala
+++ b/munit/shared/src/main/scala/munit/FailSuiteException.scala
@@ -1,0 +1,6 @@
+package munit
+
+class FailSuiteException(
+    override val message: String,
+    override val location: Location
+) extends FailException(message, location)

--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -205,7 +205,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
       notifier.fireTestAssumptionFailed(
         new Failure(
           description,
-          new IllegalStateException("Suite has been aborted.")
+          new FailSuiteException("Suite has been aborted", test.location)
         )
       )
       return Future.successful(false)

--- a/tests/shared/src/main/scala/munit/FailSuiteFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/FailSuiteFrameworkSuite.scala
@@ -20,6 +20,6 @@ object FailSuiteFrameworkSuite
          |7:  test("fail") {
          |8:    failSuite("Oops, can not do anything.")
          |9:  }
-         |==> skipped munit.FailSuiteFrameworkSuite.not gonna run - Suite has been aborted.
+         |==> skipped munit.FailSuiteFrameworkSuite.not gonna run - Suite has been aborted
          |""".stripMargin
     )

--- a/tests/shared/src/main/scala/munit/FailSuiteFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/FailSuiteFrameworkSuite.scala
@@ -1,0 +1,25 @@
+package munit
+
+class FailSuiteFrameworkSuite extends FunSuite {
+  test("pass") {
+    // println("pass")
+  }
+  test("fail") {
+    failSuite("Oops, can not do anything.")
+  }
+  test(name = "not gonna run") {
+    // println("not pass")
+  }
+}
+
+object FailSuiteFrameworkSuite
+    extends FrameworkTest(
+      classOf[FailSuiteFrameworkSuite],
+      """|==> success munit.FailSuiteFrameworkSuite.pass
+         |==> failure munit.FailSuiteFrameworkSuite.fail - /scala/munit/FailSuiteFrameworkSuite.scala:8 Oops, can not do anything.
+         |7:  test("fail") {
+         |8:    failSuite("Oops, can not do anything.")
+         |9:  }
+         |==> skipped munit.FailSuiteFrameworkSuite.not gonna run - Suite has been aborted.
+         |""".stripMargin
+    )

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -7,6 +7,7 @@ class FrameworkSuite extends BaseFrameworkSuite {
     CiOnlyFrameworkSuite,
     DiffProductFrameworkSuite,
     FailFrameworkSuite,
+    FailSuiteFrameworkSuite,
     TestNameFrameworkSuite,
     ScalaVersionFrameworkSuite,
     FixtureFrameworkSuite,


### PR DESCRIPTION
Fixes #37. Previously, it was possible to abort an individual test case based on a dynamic condition but it was not possible to abort the entire test suite. Now, users can call `failSuite("abort test suite!")` to prevent subsequent test cases from starting.