### PR TITLE
Fix buggy filtering examples from blog post.

### DIFF
--- a/munit/shared/src/main/scala/munit/FunSuite.scala
+++ b/munit/shared/src/main/scala/munit/FunSuite.scala
@@ -106,8 +106,6 @@ abstract class FunSuite
       munitExpectFailure(options, body)
     } else if (options.tags(Flaky)) {
       munitFlaky(options, body)
-    } else if (options.tags(Ignore)) {
-      Future.successful(Ignore)
     } else {
       body()
     }

--- a/website/blog/2020-02-01-hello-world.md
+++ b/website/blog/2020-02-01-hello-world.md
@@ -127,14 +127,14 @@ import scala.util.Properties
 import munit._
 object Windows213 extends Tag("Windows213")
 class MySuite extends FunSuite {
-  // reminder: type Test = GenericTest[Any]
+  // reminder: type Test = GenericTest[Future[Any]]
   override def munitNewTest(test: Test): Test = {
     val isIgnored =
-      options.tags(Windows213) && !(
+      test.tags(Windows213) && !(
         Properties.isWin &&
         Properties.versionNumberString.startsWith("2.13")
       )
-    if (isIgnored) test.withBody(() => Ignore)
+    if (isIgnored) test.tag(Ignore)
     else test
   }
 


### PR DESCRIPTION
Previously, the "rich filtering capabilities" examples from the initial
MUnit release announcement for v0.3 did not work as expected because of
the async changes in v0.5. This commit fixes the example and improves
the handling of tests with the Ignore tag.