### PR TITLE
Use consistent solution to customize tests, suites and values

### DIFF
--- a/munit/shared/src/main/scala/munit/FunFixtures.scala
+++ b/munit/shared/src/main/scala/munit/FunFixtures.scala
@@ -1,0 +1,51 @@
+package munit
+
+trait FunFixtures { self: FunSuite =>
+
+  class FunFixture[T](
+      val setup: TestOptions => T,
+      val teardown: T => Unit
+  ) {
+    def test(options: TestOptions)(
+        body: T => Any
+    )(implicit loc: Location): Unit = {
+      self.test(options) {
+        val argument = setup(options)
+        try body(argument)
+        finally teardown(argument)
+      }(loc)
+    }
+  }
+  object FunFixture {
+    def map2[A, B](a: FunFixture[A], b: FunFixture[B]): FunFixture[(A, B)] =
+      new FunFixture[(A, B)](
+        setup = { options =>
+          (a.setup(options), b.setup(options))
+        },
+        teardown = {
+          case (argumentA, argumentB) =>
+            try a.teardown(argumentA)
+            finally b.teardown(argumentB)
+        }
+      )
+    def map3[A, B, C](
+        a: FunFixture[A],
+        b: FunFixture[B],
+        c: FunFixture[C]
+    ): FunFixture[(A, B, C)] =
+      new FunFixture[(A, B, C)](
+        setup = { options =>
+          (a.setup(options), b.setup(options), c.setup(options))
+        },
+        teardown = {
+          case (argumentA, argumentB, argumentC) =>
+            try a.teardown(argumentA)
+            finally {
+              try b.teardown(argumentB)
+              finally c.teardown(argumentC)
+            }
+        }
+      )
+  }
+
+}

--- a/munit/shared/src/main/scala/munit/FunSuite.scala
+++ b/munit/shared/src/main/scala/munit/FunSuite.scala
@@ -1,195 +1,44 @@
 package munit
 
-import munit.internal.console.StackTraces
-import munit.internal.FutureCompat._
-
 import scala.collection.mutable
-import scala.util.Failure
-import scala.util.Success
 import scala.concurrent.Future
 import scala.util.control.NonFatal
-import scala.util.Try
-import scala.concurrent.duration.Duration
-import munit.internal.PlatformCompat
 
 abstract class FunSuite
     extends Suite
     with Assertions
-    with TestOptionsConversions { self =>
+    with FunFixtures
+    with TestOptionsConversions
+    with TestTransforms
+    with SuiteTransforms
+    with ValueTransforms { self =>
 
   final type TestValue = Future[Any]
 
-  def isCI: Boolean = "true" == System.getenv("CI")
-  def munitIgnore: Boolean = false
-  def munitFlakyOK: Boolean = "true" == System.getenv("MUNIT_FLAKY_OK")
-
-  private val defaultTimeout = Duration(30, "s")
-  def munitTimeout: Duration = defaultTimeout
-  val munitTestsBuffer: mutable.ArrayBuffer[Test] =
-    mutable.ArrayBuffer.empty[Test]
+  final val munitTestsBuffer: mutable.ListBuffer[Test] =
+    mutable.ListBuffer.empty[Test]
   def munitTests(): Seq[Test] = {
-    if (munitIgnore) {
-      Nil
-    } else {
-      val onlyTests = munitTestsBuffer.filter(_.tags(Only))
-      if (onlyTests.nonEmpty) {
-        if (isCI) {
-          onlyTests.toSeq.map(t =>
-            if (t.tags(Only)) {
-              t.withBody[TestValue](() =>
-                fail("'Only' tag is not allowed when `isCI=true`")(t.location)
-              )
-            } else {
-              t
-            }
-          )
-        } else {
-          onlyTests.toSeq
-        }
-      } else {
-        munitTestsBuffer.toSeq
-      }
-    }
+    munitSuiteTransform(munitTestsBuffer.toList)
   }
 
-  def munitTestValue(testValue: => Any): Future[Any] = {
-    // Takes an arbitrarily nested future `Future[Future[Future[...]]]` and
-    // returns a `Future[T]` where `T` is not a `Future`.
-    def flattenFuture(future: Future[_]): Future[_] = {
-      val nested = future.map {
-        case f: Future[_] => flattenFuture(f)
-        case x            => Future.successful(x)
-      }(munitExecutionContext)
-      nested.flattenCompat(munitExecutionContext)
-    }
-    val wrappedFuture = Future.fromTry(Try(StackTraces.dropOutside(testValue)))
-    val flatFuture = flattenFuture(wrappedFuture)
-    val awaitedFuture = PlatformCompat.waitAtMost(flatFuture, munitTimeout)
-    awaitedFuture
-  }
-
-  def munitNewTest(test: Test): Test =
-    test
-
-  def test(name: String)(
-      body: => Any
-  )(implicit loc: Location): Unit = {
+  def test(name: String)(body: => Any)(implicit loc: Location): Unit = {
     test(new TestOptions(name, Set.empty, loc))(body)
   }
-
-  def test(options: TestOptions)(
-      body: => Any
-  )(implicit loc: Location): Unit = {
-    munitTestsBuffer += munitNewTest(
+  def test(options: TestOptions)(body: => Any)(implicit loc: Location): Unit = {
+    munitTestsBuffer += munitTestTransform(
       new Test(
         options.name, { () =>
-          munitRunTest(options, () => {
-            try {
-              munitTestValue(body)
-            } catch {
-              case NonFatal(e) =>
-                Future.failed(e)
-            }
-          })
+          try {
+            munitValueTransform(body)
+          } catch {
+            case NonFatal(e) =>
+              Future.failed(e)
+          }
         },
         options.tags.toSet,
         loc
       )
     )
-  }
-
-  def munitRunTest(
-      options: TestOptions,
-      body: () => Future[Any]
-  ): Future[Any] = {
-    if (options.tags(Fail)) {
-      munitExpectFailure(options, body)
-    } else if (options.tags(Flaky)) {
-      munitFlaky(options, body)
-    } else {
-      body()
-    }
-  }
-
-  def munitFlaky(
-      options: TestOptions,
-      body: () => Future[Any]
-  ): Future[Any] = {
-    body().transformCompat {
-      case Success(value) => Success(value)
-      case Failure(exception) =>
-        if (munitFlakyOK) {
-          Success(new TestValues.FlakyFailure(exception))
-        } else {
-          throw exception
-        }
-    }(munitExecutionContext)
-  }
-
-  def munitExpectFailure(
-      options: TestOptions,
-      body: () => Future[Any]
-  ): Future[Any] = {
-    body().transformCompat {
-      case Success(value) =>
-        Failure(
-          throw new FailException(
-            munitLines.formatLine(
-              options.location,
-              "expected failure but test passed"
-            ),
-            options.location
-          )
-        )
-      case Failure(exception) =>
-        Success(())
-    }(munitExecutionContext)
-  }
-
-  class FunFixture[T](
-      val setup: TestOptions => T,
-      val teardown: T => Unit
-  ) {
-    def test(options: TestOptions)(
-        body: T => Any
-    )(implicit loc: Location): Unit = {
-      self.test(options) {
-        val argument = setup(options)
-        try body(argument)
-        finally teardown(argument)
-      }(loc)
-    }
-  }
-  object FunFixture {
-    def map2[A, B](a: FunFixture[A], b: FunFixture[B]): FunFixture[(A, B)] =
-      new FunFixture[(A, B)](
-        setup = { options =>
-          (a.setup(options), b.setup(options))
-        },
-        teardown = {
-          case (argumentA, argumentB) =>
-            try a.teardown(argumentA)
-            finally b.teardown(argumentB)
-        }
-      )
-    def map3[A, B, C](
-        a: FunFixture[A],
-        b: FunFixture[B],
-        c: FunFixture[C]
-    ): FunFixture[(A, B, C)] =
-      new FunFixture[(A, B, C)](
-        setup = { options =>
-          (a.setup(options), b.setup(options), c.setup(options))
-        },
-        teardown = {
-          case (argumentA, argumentB, argumentC) =>
-            try a.teardown(argumentA)
-            finally {
-              try b.teardown(argumentB)
-              finally c.teardown(argumentC)
-            }
-        }
-      )
   }
 
 }

--- a/munit/shared/src/main/scala/munit/GenericTest.scala
+++ b/munit/shared/src/main/scala/munit/GenericTest.scala
@@ -29,6 +29,10 @@ class GenericTest[T](
     withTags(tags + newTag)
   def withLocation(newLocation: Location): GenericTest[T] =
     copy(location = newLocation)
+
+  def withBodyMap[A](newBody: T => A): GenericTest[A] =
+    withBody[A](() => newBody(body()))
+
   private[this] def copy[A](
       name: String = this.name,
       body: () => A = this.body,

--- a/munit/shared/src/main/scala/munit/SuiteTransforms.scala
+++ b/munit/shared/src/main/scala/munit/SuiteTransforms.scala
@@ -1,0 +1,64 @@
+package munit
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+trait SuiteTransforms { this: FunSuite =>
+
+  final class SuiteTransform(val name: String, fn: List[Test] => List[Test])
+      extends Function1[List[Test], List[Test]] {
+    def apply(v1: List[Test]): List[Test] = fn(v1)
+  }
+
+  def munitSuiteTransforms: List[SuiteTransform] =
+    List(
+      munitIgnoreSuiteTransform,
+      munitOnlySuiteTransform
+    )
+
+  final def munitSuiteTransform(tests: List[Test]): List[Test] = {
+    try {
+      munitSuiteTransforms.foldLeft(tests) {
+        case (ts, fn) => fn(ts)
+      }
+    } catch {
+      case NonFatal(e) =>
+        List(
+          new Test(
+            "munitSuiteTransform",
+            () => Future.failed(e)
+          )(Location.empty)
+        )
+    }
+  }
+
+  def munitIgnore: Boolean = false
+  final def munitIgnoreSuiteTransform: SuiteTransform =
+    new SuiteTransform("munitIgnore", { tests =>
+      if (munitIgnore) Nil
+      else tests
+    })
+
+  def isCI: Boolean = "true" == System.getenv("CI")
+  final def munitOnlySuiteTransform: SuiteTransform =
+    new SuiteTransform("only", { tests =>
+      val onlySuite = tests.filter(_.tags(Only))
+      if (onlySuite.nonEmpty) {
+        if (!isCI) {
+          onlySuite
+        } else {
+          onlySuite.map(t =>
+            if (t.tags(Only)) {
+              t.withBody[TestValue](() =>
+                fail("'Only' tag is not allowed when `isCI=true`")(t.location)
+              )
+            } else {
+              t
+            }
+          )
+        }
+      } else {
+        tests
+      }
+    })
+}

--- a/munit/shared/src/main/scala/munit/TestTransforms.scala
+++ b/munit/shared/src/main/scala/munit/TestTransforms.scala
@@ -1,0 +1,75 @@
+package munit
+
+import munit.internal.FutureCompat._
+import scala.util.Success
+import scala.util.Failure
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+trait TestTransforms { this: FunSuite =>
+
+  final class TestTransform(val name: String, fn: Test => Test)
+      extends Function1[Test, Test] {
+    def apply(v1: Test): Test = fn(v1)
+  }
+
+  def munitTestTransforms: List[TestTransform] =
+    List(
+      munitFailTransform,
+      munitFlakyTransform
+    )
+
+  final def munitTestTransform(test: Test): Test = {
+    try {
+      munitTestTransforms.foldLeft(test) {
+        case (t, fn) => fn(t)
+      }
+    } catch {
+      case NonFatal(e) =>
+        test.withBody[TestValue](() => Future.failed(e))
+    }
+  }
+
+  final def munitFailTransform: TestTransform =
+    new TestTransform("fail", { t =>
+      if (t.tags(Fail)) {
+        t.withBodyMap[TestValue](
+          _.transformCompat {
+            case Success(value) =>
+              Failure(
+                throw new FailException(
+                  munitLines.formatLine(
+                    t.location,
+                    "expected failure but test passed"
+                  ),
+                  t.location
+                )
+              )
+            case Failure(exception) =>
+              Success(())
+          }(munitExecutionContext)
+        )
+      } else {
+        t
+      }
+    })
+
+  def munitFlakyOK: Boolean = "true" == System.getenv("MUNIT_FLAKY_OK")
+  final def munitFlakyTransform: TestTransform =
+    new TestTransform("flaky", { t =>
+      if (t.tags(Flaky)) {
+        t.withBodyMap(_.transformCompat {
+          case Success(value) => Success(value)
+          case Failure(exception) =>
+            if (munitFlakyOK) {
+              Success(new TestValues.FlakyFailure(exception))
+            } else {
+              throw exception
+            }
+        }(munitExecutionContext))
+      } else {
+        t
+      }
+    })
+
+}

--- a/munit/shared/src/main/scala/munit/ValueTransforms.scala
+++ b/munit/shared/src/main/scala/munit/ValueTransforms.scala
@@ -1,0 +1,50 @@
+package munit
+
+import scala.concurrent.Future
+import munit.internal.FutureCompat._
+import scala.util.Try
+import munit.internal.console.StackTraces
+import munit.internal.PlatformCompat
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
+
+trait ValueTransforms { this: FunSuite =>
+
+  final class ValueTransform(
+      val name: String,
+      fn: PartialFunction[Any, Future[Any]]
+  ) extends Function1[Any, Option[Future[Any]]] {
+    def apply(v1: Any): Option[Future[Any]] = fn.lift(v1)
+  }
+
+  def munitValueTransforms: List[ValueTransform] =
+    List(
+      munitFutureTransform
+    )
+
+  def munitTimeout: Duration = new FiniteDuration(30, TimeUnit.SECONDS)
+  final def munitValueTransform(testValue: => Any): Future[Any] = {
+    // Takes an arbitrarily nested future `Future[Future[Future[...]]]` and
+    // returns a `Future[T]` where `T` is not a `Future`.
+    def flattenFuture(future: Future[_]): Future[_] = {
+      val nested: Future[Future[Any]] = future.map { value =>
+        val transformed = munitValueTransforms.iterator
+          .map(fn => fn(value))
+          .collectFirst { case Some(future) => future }
+        transformed match {
+          case Some(f) => flattenFuture(f)
+          case None    => Future.successful(value)
+        }
+      }(munitExecutionContext)
+      nested.flattenCompat(munitExecutionContext)
+    }
+    val wrappedFuture = Future.fromTry(Try(StackTraces.dropOutside(testValue)))
+    val flatFuture = flattenFuture(wrappedFuture)
+    val awaitedFuture = PlatformCompat.waitAtMost(flatFuture, munitTimeout)
+    awaitedFuture
+  }
+
+  final def munitFutureTransform: ValueTransform =
+    new ValueTransform("Future", { case e: Future[_] => e })
+}

--- a/tests/shared/src/main/scala/munit/ScalaVersionFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaVersionFrameworkSuite.scala
@@ -2,8 +2,14 @@ package munit
 
 class ScalaVersionFrameworkSuite extends munit.FunSuite {
   val scalaVersion = "2.12.100"
-  override def munitNewTest(test: Test): Test =
-    test.withName(test.name + "-" + scalaVersion)
+
+  override def munitTestTransforms: List[TestTransform] =
+    super.munitTestTransforms ++ List(
+      new TestTransform("append scala version", { test =>
+        test.withName(test.name + "-" + scalaVersion)
+      })
+    )
+
   test("foo") {
     assertEquals(List(1).head, 1)
   }

--- a/tests/shared/src/main/scala/munit/SuiteTransformCrashFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/SuiteTransformCrashFrameworkSuite.scala
@@ -1,0 +1,15 @@
+package munit
+
+class SuiteTransformCrashFrameworkSuite extends munit.FunSuite {
+  override val munitSuiteTransforms: List[SuiteTransform] = List(
+    new SuiteTransform("boom", tests => ???)
+  )
+
+  test("hello") {}
+}
+object SuiteTransformCrashFrameworkSuite
+    extends FrameworkTest(
+      classOf[SuiteTransformCrashFrameworkSuite],
+      """|==> failure munit.SuiteTransformCrashFrameworkSuite.munitSuiteTransform - an implementation is missing
+         |""".stripMargin
+    )

--- a/tests/shared/src/main/scala/munit/SuiteTransformFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/SuiteTransformFrameworkSuite.scala
@@ -1,0 +1,22 @@
+package munit
+
+class SuiteTransformFrameworkSuite extends munit.FunSuite {
+  override val munitSuiteTransforms: List[SuiteTransform] = List(
+    new SuiteTransform(
+      "hello",
+      tests => tests.filter(_.name.startsWith("hello"))
+    )
+  )
+
+  test("hello") {}
+  test("hello-yes") {}
+  test("goodbye") {}
+  test("goodbye-yes") {}
+}
+object SuiteTransformFrameworkSuite
+    extends FrameworkTest(
+      classOf[SuiteTransformFrameworkSuite],
+      """|==> success munit.SuiteTransformFrameworkSuite.hello
+         |==> success munit.SuiteTransformFrameworkSuite.hello-yes
+         |""".stripMargin
+    )

--- a/tests/shared/src/main/scala/munit/TestTransformCrashFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/TestTransformCrashFrameworkSuite.scala
@@ -1,0 +1,15 @@
+package munit
+
+class TestTransformCrashFrameworkSuite extends munit.FunSuite {
+  override val munitTestTransforms: List[TestTransform] = List(
+    new TestTransform("boom", test => ???)
+  )
+
+  test("hello") {}
+}
+object TestTransformCrashFrameworkSuite
+    extends FrameworkTest(
+      classOf[TestTransformCrashFrameworkSuite],
+      """|==> failure munit.TestTransformCrashFrameworkSuite.hello - an implementation is missing
+         |""".stripMargin
+    )

--- a/tests/shared/src/main/scala/munit/TestTransformFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/TestTransformFrameworkSuite.scala
@@ -1,0 +1,15 @@
+package munit
+
+class TestTransformFrameworkSuite extends munit.FunSuite {
+  override val munitTestTransforms: List[TestTransform] = List(
+    new TestTransform("ok", test => test.withName(test.name + "-ok"))
+  )
+
+  test("hello") {}
+}
+object TestTransformFrameworkSuite
+    extends FrameworkTest(
+      classOf[TestTransformFrameworkSuite],
+      """|==> success munit.TestTransformFrameworkSuite.hello-ok
+         |""".stripMargin
+    )

--- a/tests/shared/src/main/scala/munit/ValueTransformCrashFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ValueTransformCrashFrameworkSuite.scala
@@ -1,0 +1,15 @@
+package munit
+
+class ValueTransformCrashFrameworkSuite extends munit.FunSuite {
+  override val munitValueTransforms: List[ValueTransform] = List(
+    new ValueTransform("boom", { case test => ??? })
+  )
+
+  test("hello") {}
+}
+object ValueTransformCrashFrameworkSuite
+    extends FrameworkTest(
+      classOf[ValueTransformCrashFrameworkSuite],
+      """|==> failure munit.ValueTransformCrashFrameworkSuite.hello - an implementation is missing
+         |""".stripMargin
+    )

--- a/tests/shared/src/main/scala/munit/ValueTransformFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ValueTransformFrameworkSuite.scala
@@ -1,0 +1,21 @@
+package munit
+
+import scala.concurrent.Future
+
+class ValueTransformFrameworkSuite extends munit.FunSuite {
+  override val munitValueTransforms: List[ValueTransform] = List(
+    new ValueTransform("number", {
+      case 42 => Future.failed(new Exception("boom"))
+    })
+  )
+
+  test("explode") { 42 }
+  test("ok") { 41 }
+}
+object ValueTransformFrameworkSuite
+    extends FrameworkTest(
+      classOf[ValueTransformFrameworkSuite],
+      """|==> failure munit.ValueTransformFrameworkSuite.explode - boom
+         |==> success munit.ValueTransformFrameworkSuite.ok
+         |""".stripMargin
+    )

--- a/tests/shared/src/test/scala/munit/BaseSuite.scala
+++ b/tests/shared/src/test/scala/munit/BaseSuite.scala
@@ -1,25 +1,24 @@
 package munit
 
 import munit.internal.PlatformCompat
-import scala.concurrent.Future
 
 class BaseSuite extends FunSuite {
-  override def munitRunTest(
-      options: TestOptions,
-      body: () => Future[Any]
-  ): Future[Any] = {
-    def isDotty: Boolean =
-      BuildInfo.scalaVersion.startsWith("0.")
-    def is213: Boolean =
-      BuildInfo.scalaVersion.startsWith("2.13") || isDotty
-    if (options.tags(NoDotty) && isDotty) {
-      Future.successful(Ignore)
-    } else if (options.tags(Only213) && !is213) {
-      Future.successful(Ignore)
-    } else if (options.tags(OnlyJVM) && !PlatformCompat.isJVM) {
-      Future.successful(Ignore)
-    } else {
-      super.munitRunTest(options, body)
-    }
-  }
+  override def munitTestTransforms: List[TestTransform] =
+    super.munitTestTransforms ++ List(
+      new TestTransform("BaseSuite", { test =>
+        def isDotty: Boolean =
+          BuildInfo.scalaVersion.startsWith("0.")
+        def is213: Boolean =
+          BuildInfo.scalaVersion.startsWith("2.13") || isDotty
+        if (test.tags(NoDotty) && isDotty) {
+          test.tag(Ignore)
+        } else if (test.tags(Only213) && !is213) {
+          test.tag(Ignore)
+        } else if (test.tags(OnlyJVM) && !PlatformCompat.isJVM) {
+          test.tag(Ignore)
+        } else {
+          test
+        }
+      })
+    )
 }

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -13,7 +13,13 @@ class FrameworkSuite extends BaseFrameworkSuite {
     FixtureFrameworkSuite,
     TagsIncludeFramweworkSuite,
     TagsIncludeExcludeFramweworkSuite,
-    TagsExcludeFramweworkSuite
+    TagsExcludeFramweworkSuite,
+    SuiteTransformCrashFrameworkSuite,
+    SuiteTransformFrameworkSuite,
+    TestTransformCrashFrameworkSuite,
+    TestTransformFrameworkSuite,
+    ValueTransformCrashFrameworkSuite,
+    ValueTransformFrameworkSuite
   )
   tests.foreach { t =>
     check(t)

--- a/website/blog/2020-02-01-hello-world.md
+++ b/website/blog/2020-02-01-hello-world.md
@@ -127,16 +127,17 @@ import scala.util.Properties
 import munit._
 object Windows213 extends Tag("Windows213")
 class MySuite extends FunSuite {
-  // reminder: type Test = GenericTest[Future[Any]]
-  override def munitNewTest(test: Test): Test = {
-    val isIgnored =
-      test.tags(Windows213) && !(
-        Properties.isWin &&
-        Properties.versionNumberString.startsWith("2.13")
-      )
-    if (isIgnored) test.tag(Ignore)
-    else test
-  }
+  override def munitTestTransforms = super.munitTestTransforms ++ List(
+    new TestTransform("Windows213", { test =>
+      val isIgnored =
+        test.tags(Windows213) && !(
+          Properties.isWin &&
+            Properties.versionNumberString.startsWith("2.13")
+        )
+      if (isIgnored) test.tag(Ignore)
+      else test
+    })
+  )
 
   test("windows-213".tag(Windows213)) {
     // Only runs when operating system is Windows and Scala version is 2.13
@@ -145,6 +146,7 @@ class MySuite extends FunSuite {
     // Always runs like a normal test.
   }
 }
+
 ```
 
 By encoding the environment requirements in the test implementation, we prevent


### PR DESCRIPTION
Opening this as an alternative proposal to #61 (cc/ @kubukoz).

Previously, users could override several methods to customize how tests
were transformed, how suites filtered tests and how values got lifted
into futures. While this system worked OK, it wasn't easy to explain
since it was quite inconsistent.

Now, this commit introduces three consistent solutions to transform:

* test cases: a function `Test => Test`
* test suites: a function `List[Test] => List[Test]`
* test values: a partial function `Any => Future[Any]`

Users register new transforms using a similar API as you register fixtures:

```scala
  override def munitTestTransforms: List[TestTransform] =
    super.munitTestTransforms ++ List(
      new TestTransform("append scala version", { test =>
        test.withName(test.name + "-" + scalaVersion)
      })
    )
```

Opening this as a draft PR to see what people think. It's quite a breaking change but at the moment I feel like it's a nice improvement. 