### PR TITLE
fixes to support dotty 0.23

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val scalaNativeVersion = "0.4.0-M2"
 def scala213 = "2.13.1"
 def scala212 = "2.12.10"
 def scala211 = "2.11.12"
-def dotty = "0.22.0-RC1"
+def dotty = "0.23.0-RC1"
 def scalameta = "4.3.0"
 def gcp = "com.google.cloud" % "google-cloud-storage" % "1.103.0"
 inThisBuild(

--- a/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
@@ -10,8 +10,8 @@ object MacroCompat {
     inline implicit def generate: Location = ${ locationImpl() }
   }
 
-  def locationImpl()(given qctx: QuoteContext): Expr[Location] = {
-    import qctx.tasty.{_, given}
+  def locationImpl()(implicit qctx: QuoteContext): Expr[Location] = {
+    import qctx.tasty.{_, given _}
     val path = rootPosition.sourceFile.jpath.toString
     val startLine = rootPosition.startLine + 1
     '{ new Location(${Expr(path)}, ${Expr(startLine)}) }
@@ -21,8 +21,8 @@ object MacroCompat {
     inline implicit def generate[T](value: T): Clue[T] = ${ clueImpl('value) }
   }
 
-  def clueImpl[T:Type](value: Expr[T])(given qctx: QuoteContext): Expr[Clue[T]] = {
-    import qctx.tasty.{_, given}
+  def clueImpl[T:Type](value: Expr[T])(implicit qctx: QuoteContext): Expr[Clue[T]] = {
+    import qctx.tasty.{_, given _}
     val source = value.unseal.pos.sourceCode
     val valueType = implicitly[scala.quoted.Type[T]].show
     '{ new Clue(${Expr(source)}, $value, ${Expr(valueType)}) }


### PR DESCRIPTION
Dotty 0.23.0-RC1 just dropped.  This PR updates to this version, including some minor fixes due to the change between Dotty 0.22 and 0.23.