### PR TITLE
Add munit-scalacheck module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,9 @@ val customScalaJSVersion = Option(System.getenv("SCALAJS_VERSION"))
 val scalaJSVersion = customScalaJSVersion.getOrElse("1.0.0")
 val scalaNativeVersion = "0.4.0-M2"
 def scala213 = "2.13.1"
-def scala212 = "2.12.10"
+def scala212 = "2.12.11"
 def scala211 = "2.11.12"
 def dotty = "0.23.0-RC1"
-def scalameta = "4.3.0"
 def junitVersion = "4.13"
 def gcp = "com.google.cloud" % "google-cloud-storage" % "1.103.0"
 inThisBuild(
@@ -201,8 +200,23 @@ lazy val plugin = project
     )
   )
 
-lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+lazy val munitScalacheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .in(file("munit-scalacheck"))
+  .settings(
+    sharedSettings,
+    crossScalaVersions := List(scala213, scala212, scala211),
+    libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.3"
+  )
+  .nativeConfigure(sharedNativeConfigure)
+  .nativeSettings(
+    sharedNativeSettings,
+    skip in publish := customScalaJSVersion.isDefined
+  )
+  .jsSettings(sharedJSSettings)
   .dependsOn(munit)
+
+lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .dependsOn(munit, munitScalacheck)
   .enablePlugins(BuildInfoPlugin)
   .settings(
     sharedSettings,

--- a/build.sbt
+++ b/build.sbt
@@ -202,10 +202,12 @@ lazy val plugin = project
 
 lazy val munitScalacheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("munit-scalacheck"))
+  .dependsOn(munit)
   .settings(
     sharedSettings,
-    crossScalaVersions := List(scala213, scala212, scala211),
-    libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.3"
+    crossScalaVersions := List(scala213, scala212, scala211, dotty),
+    libraryDependencies += ("org.scalacheck" %%% "scalacheck" % "1.14.3")
+      .withDottyCompat(scalaVersion.value)
   )
   .nativeConfigure(sharedNativeConfigure)
   .nativeSettings(
@@ -213,7 +215,6 @@ lazy val munitScalacheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     skip in publish := customScalaJSVersion.isDefined
   )
   .jsSettings(sharedJSSettings)
-  .dependsOn(munit)
 
 lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .dependsOn(munit, munitScalacheck)

--- a/munit-scalacheck/shared/src/main/scala/munit/scalacheck/ScalaCheckFailException.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/scalacheck/ScalaCheckFailException.scala
@@ -1,0 +1,7 @@
+package munit.scalacheck
+
+import scala.util.control.NoStackTrace
+
+class ScalaCheckFailException(message: String)
+    extends Exception(message)
+    with NoStackTrace

--- a/munit-scalacheck/shared/src/main/scala/munit/scalacheck/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/scalacheck/ScalaCheckSuite.scala
@@ -9,19 +9,25 @@ import scala.concurrent.Future
 trait ScalaCheckSuite extends FunSuite {
 
   def property(
+      name: String
+  )(body: => Prop)(implicit loc: Location): Unit = {
+    property(new TestOptions(name, Set.empty, loc))(body)
+  }
+
+  def property(
       options: TestOptions
   )(body: => Prop)(implicit loc: Location): Unit = {
     test(options)(body)
   }
 
   override def munitValueTransforms: List[ValueTransform] =
-    super.munitValueTransforms :+ scalaCheckPropTrasform
+    super.munitValueTransforms :+ scalaCheckPropTransform
 
   protected def scalaCheckTestParameters = ScalaCheckTest.Parameters.default
 
   protected def scalaCheckPrettyParameters = Pretty.defaultParams
 
-  private def scalaCheckPropTrasform: ValueTransform =
+  private def scalaCheckPropTransform: ValueTransform =
     new ValueTransform("ScalaCheck Prop", {
       case prop: Prop =>
         val result = ScalaCheckTest.check(scalaCheckTestParameters, prop)
@@ -29,11 +35,8 @@ trait ScalaCheckSuite extends FunSuite {
         if (result.passed) {
           println(prettyResult)
           Future.successful(())
-        } else
-          Future.failed {
-            val e = new Exception("\n" + prettyResult)
-            e.setStackTrace(Array.empty)
-            e
-          }
+        } else {
+          Future.failed(new ScalaCheckFailException("\n" + prettyResult))
+        }
     })
 }

--- a/munit-scalacheck/shared/src/main/scala/munit/scalacheck/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/scalacheck/ScalaCheckSuite.scala
@@ -1,0 +1,39 @@
+package munit
+package scalacheck
+
+import org.scalacheck.Prop
+import org.scalacheck.{Test => ScalaCheckTest}
+import org.scalacheck.util.Pretty
+import scala.concurrent.Future
+
+abstract class ScalaCheckSuite extends FunSuite {
+
+  def property(
+      options: TestOptions
+  )(body: => Prop)(implicit loc: Location): Unit = {
+    test(options)(body)
+  }
+
+  override def munitValueTransforms: List[ValueTransform] =
+    super.munitValueTransforms ++ List(
+      new ValueTransform("ScalaCheck Prop", {
+        case prop: Prop =>
+          val result = ScalaCheckTest.check(scalaCheckTestParameters, prop)
+          val prettyResult = Pretty.pretty(result, scalaCheckPrettyParameters)
+          if (result.passed) {
+            println(prettyResult)
+            Future.successful(())
+          } else
+            Future.failed {
+              val e = new Exception("\n" + prettyResult)
+              e.setStackTrace(Array.empty)
+              e
+            }
+      })
+    )
+
+  protected def scalaCheckTestParameters = ScalaCheckTest.Parameters.default
+
+  protected def scalaCheckPrettyParameters = Pretty.defaultParams
+
+}

--- a/munit-scalacheck/shared/src/main/scala/munit/scalacheck/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/scalacheck/ScalaCheckSuite.scala
@@ -6,7 +6,7 @@ import org.scalacheck.{Test => ScalaCheckTest}
 import org.scalacheck.util.Pretty
 import scala.concurrent.Future
 
-abstract class ScalaCheckSuite extends FunSuite {
+trait ScalaCheckSuite extends FunSuite {
 
   def property(
       options: TestOptions
@@ -15,25 +15,25 @@ abstract class ScalaCheckSuite extends FunSuite {
   }
 
   override def munitValueTransforms: List[ValueTransform] =
-    super.munitValueTransforms ++ List(
-      new ValueTransform("ScalaCheck Prop", {
-        case prop: Prop =>
-          val result = ScalaCheckTest.check(scalaCheckTestParameters, prop)
-          val prettyResult = Pretty.pretty(result, scalaCheckPrettyParameters)
-          if (result.passed) {
-            println(prettyResult)
-            Future.successful(())
-          } else
-            Future.failed {
-              val e = new Exception("\n" + prettyResult)
-              e.setStackTrace(Array.empty)
-              e
-            }
-      })
-    )
+    super.munitValueTransforms :+ scalaCheckPropTrasform
 
   protected def scalaCheckTestParameters = ScalaCheckTest.Parameters.default
 
   protected def scalaCheckPrettyParameters = Pretty.defaultParams
 
+  private def scalaCheckPropTrasform: ValueTransform =
+    new ValueTransform("ScalaCheck Prop", {
+      case prop: Prop =>
+        val result = ScalaCheckTest.check(scalaCheckTestParameters, prop)
+        val prettyResult = Pretty.pretty(result, scalaCheckPrettyParameters)
+        if (result.passed) {
+          println(prettyResult)
+          Future.successful(())
+        } else
+          Future.failed {
+            val e = new Exception("\n" + prettyResult)
+            e.setStackTrace(Array.empty)
+            e
+          }
+    })
 }

--- a/tests/shared/src/main/scala/munit/scalacheck/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/scalacheck/ScalaCheckFrameworkSuite.scala
@@ -1,0 +1,34 @@
+package munit
+package scalacheck
+
+import org.scalacheck.Prop.forAll
+import org.scalacheck.rng.Seed
+
+class ScalaCheckFrameworkSuite extends ScalaCheckSuite {
+
+  override def scalaCheckTestParameters =
+    super.scalaCheckTestParameters.withInitialSeed(Seed(123L))
+
+  property("list concatenation") {
+    forAll { (l1: List[Int], l2: List[Int]) =>
+      l1.size + l2.size == (l1 ::: l2).size
+    }
+  }
+
+  property("squared") {
+    forAll { (n: Int) =>
+      scala.math.sqrt(n * n) == n
+    }
+  }
+}
+
+object ScalaCheckFrameworkSuite
+    extends FrameworkTest(
+      classOf[ScalaCheckFrameworkSuite],
+      s"""|==> success munit.scalacheck.ScalaCheckFrameworkSuite.list concatenation
+          |==> failure munit.scalacheck.ScalaCheckFrameworkSuite.squared -${' '}
+          |Falsified after 0 passed tests.
+          |> ARG_0: -1
+          |> ARG_0_ORIGINAL: 2147483647
+          |""".stripMargin
+    )

--- a/tests/shared/src/main/scala/munit/scalacheck/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/scalacheck/ScalaCheckFrameworkSuite.scala
@@ -6,6 +6,8 @@ import org.scalacheck.rng.Seed
 
 class ScalaCheckFrameworkSuite extends ScalaCheckSuite {
 
+  // NOTE(gabro): this is needed for making the test output stable for the failed test below.
+  // It also serves as a test for overriding these parameters.
   override def scalaCheckTestParameters =
     super.scalaCheckTestParameters.withInitialSeed(Seed(123L))
 

--- a/tests/shared/src/main/scala/munit/scalacheck/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/scalacheck/ScalaCheckFrameworkSuite.scala
@@ -22,6 +22,12 @@ class ScalaCheckFrameworkSuite extends ScalaCheckSuite {
       scala.math.sqrt(n * n) == n
     }
   }
+
+  property("tagged".tag(new Tag("a"))) {
+    forAll { (n: Int) =>
+      n + 0 == n
+    }
+  }
 }
 
 object ScalaCheckFrameworkSuite
@@ -32,5 +38,6 @@ object ScalaCheckFrameworkSuite
           |Falsified after 0 passed tests.
           |> ARG_0: -1
           |> ARG_0_ORIGINAL: 2147483647
+          |==> success munit.scalacheck.ScalaCheckFrameworkSuite.tagged
           |""".stripMargin
     )

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -19,7 +19,8 @@ class FrameworkSuite extends BaseFrameworkSuite {
     TestTransformCrashFrameworkSuite,
     TestTransformFrameworkSuite,
     ValueTransformCrashFrameworkSuite,
-    ValueTransformFrameworkSuite
+    ValueTransformFrameworkSuite,
+    scalacheck.ScalaCheckFrameworkSuite
   )
   tests.foreach { t =>
     check(t)


### PR DESCRIPTION
This PR adds a new `munit-scalacheck` module which provides a basic level of integration with ScalaCheck via `ScalaCheckSuite`.

Example usage:

```scala
class ScalaCheckFrameworkSuite extends ScalaCheckSuite {

  property("list concatenation") {
    forAll { (l1: List[Int], l2: List[Int]) =>
      l1.size + l2.size == (l1 ::: l2).size
    }
  }

  property("squared") {
    forAll { (n: Int) =>
      scala.math.sqrt(n * n) == n
    }
  }
}
```

Example output:

```
munit.scalacheck.ScalaCheckFrameworkSuite:
OK, passed 100 tests.
  + list concatenation 0.454s
==> X munit.scalacheck.ScalaCheckFrameworkSuite.squared  0.03s java.lang.Exception: 
Falsified after 0 passed tests.
> ARG_0: -1
> ARG_0_ORIGINAL: 2147483647
```