### PR TITLE
Allow using MUnit assertions in ScalaCheck props

### DIFF
--- a/docs/integrations/scalacheck.md
+++ b/docs/integrations/scalacheck.md
@@ -6,7 +6,7 @@ title: ScalaCheck
 MUnit supports writing property-based tests using
 [ScalaCheck](http://www.scalacheck.org/).
 
-## Getting Started
+## Getting started
 
 ScalaCheck support is provided as a separate module. You can add it to your
 build via:
@@ -56,6 +56,42 @@ class IntegerSuite extends ScalaCheckSuite {
 > }
 > ```
 
+## Using assertions
+
+ScalaCheck supports writing property checks as boolean expressions (as in the
+examples above).
+
+In MUnit you can also use [assertions](../assertions.md) to verify properties:
+
+```scala mdoc:reset
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop._
+
+class IntegerSuite extends ScalaCheckSuite {
+
+  property("integer identities") {
+    forAll { (n: Int) =>
+      assertEquals(n + 0, n)
+      assertEquals(n * 1, n)
+    }
+  }
+
+}
+```
+
+The property above is equivalent to
+
+```scala
+property("integer identities") {
+  forAll { (n: Int) =>
+    (n + 0 == n) && (n * 1 == n)
+  }
+}
+```
+
+but it provides better error reporting by including the source location of the
+failed assertion, which is not possible when using boolean expressions.
+
 ## Configuring ScalaCheck
 
 You can override the `scalaCheckTestParameters` property of `ScalaCheckSuite` to
@@ -87,7 +123,7 @@ ScalaTest provides two styles for writing property-based tests, which are both
 front-ends to ScalaCheck.
 
 If you are using the "ScalaCheck style" API, i.e. the `Checkers` trait,
-switching to MUnit requires very minor and mechanical changes:
+switching to MUnit requires minor mechanical changes:
 
 ```diff
 -import org.scalatest.prop.Checkers
@@ -110,12 +146,11 @@ switching to MUnit requires very minor and mechanical changes:
 ```
 
 If you're using the "ScalaTest style" API, i.e. the
-`GeneratorDrivenPropertyChecks` trait, switching to MUnit requires a little more
-work: MUnit does not provide an API over ScalaCheck like ScalaTest does, so you
-will need to use the ScalaCheck API directly.
+`GeneratorDrivenPropertyChecks` trait, switching to MUnit requires again a few
+changes, typically including the property body.
 
-For example, if you are using ScalaTest matchers, you will need to convert them
-to boolean checks:
+For example, if you are using ScalaTest matchers you will need to convert them
+to MUnit assertions:
 
 ```diff
 -import org.scalatest.Matchers
@@ -133,8 +168,8 @@ to boolean checks:
      forAll { (n1: Int, n2: Int) =>
 -      (n1 + n2) should be (n2 + n1)
 -      (n1 * n2) should be (n2 * n1)
-+      n1 + n2 == n2 + n1 &&
-+      n1 * n2 == n2 * n1
++      assertEquals(n1 + n2, n2 + n1)
++      assertEquals(n1 * n2, n2 * n1)
      }
    }
 

--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -3,7 +3,10 @@ package munit
 import org.scalacheck.Prop
 import org.scalacheck.{Test => ScalaCheckTest}
 import org.scalacheck.util.Pretty
-import scala.concurrent.Future
+import scala.util.Success
+import scala.util.Failure
+import scala.util.Try
+import munit.internal.FutureCompat._
 
 trait ScalaCheckSuite extends FunSuite {
 
@@ -19,23 +22,46 @@ trait ScalaCheckSuite extends FunSuite {
     test(options)(body)
   }
 
-  override def munitValueTransforms: List[ValueTransform] =
-    super.munitValueTransforms :+ scalaCheckPropTransform
+  // Allow property bodies of type Unit
+  // This is done to support using MUnit assertions in property bodies
+  // instead of returning a Boolean.
+  implicit def unitToProp: Unit => Prop = _ => Prop.passed
+
+  override def munitTestTransforms: List[TestTransform] =
+    super.munitTestTransforms :+ scalaCheckPropTransform
 
   protected def scalaCheckTestParameters = ScalaCheckTest.Parameters.default
 
   protected def scalaCheckPrettyParameters = Pretty.defaultParams
 
-  private def scalaCheckPropTransform: ValueTransform =
-    new ValueTransform("ScalaCheck Prop", {
-      case prop: Prop =>
-        val result = ScalaCheckTest.check(scalaCheckTestParameters, prop)
-        val prettyResult = Pretty.pretty(result, scalaCheckPrettyParameters)
-        if (result.passed) {
-          println(prettyResult)
-          Future.successful(())
-        } else {
-          Future.failed(new ScalaCheckFailException("\n" + prettyResult))
-        }
+  private val scalaCheckPropTransform: TestTransform =
+    new TestTransform("ScalaCheck Prop", t => {
+      t.withBodyMap[TestValue](
+        _.transformCompat {
+          case Success(prop: Prop) => propToTry(prop, t.location)
+          case r                   => r
+        }(munitExecutionContext)
+      )
     })
+
+  private def propToTry(prop: Prop, testLocation: Location): Try[Unit] = {
+    import ScalaCheckTest._
+    val result = check(scalaCheckTestParameters, prop)
+    def renderResult(r: Result) =
+      Pretty.pretty(r, scalaCheckPrettyParameters)
+
+    result.status match {
+      case Passed | Proved(_) =>
+        println(renderResult(result))
+        Success(())
+      case status @ PropException(_, e: FailException, _) =>
+        // Promote FailException (i.e failed assertions) to property failures
+        val r = result.copy(status = Failed(status.args, status.labels))
+        Failure(e.withMessage(e.getMessage() + "\n\n" + renderResult(r)))
+      case _ =>
+        // Fail using the test location
+        Try(fail("\n" + renderResult(result))(testLocation))
+    }
+  }
+
 }

--- a/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
@@ -10,13 +10,13 @@ class ScalaCheckFrameworkSuite extends ScalaCheckSuite {
   override def scalaCheckTestParameters =
     super.scalaCheckTestParameters.withInitialSeed(Seed(123L))
 
-  property("list concatenation") {
+  property("boolean check (true)") {
     forAll { (l1: List[Int], l2: List[Int]) =>
       l1.size + l2.size == (l1 ::: l2).size
     }
   }
 
-  property("squared") {
+  property("boolean check (false)") {
     forAll { (n: Int) =>
       scala.math.sqrt(n * n) == n
     }
@@ -27,16 +27,51 @@ class ScalaCheckFrameworkSuite extends ScalaCheckSuite {
       n + 0 == n
     }
   }
+
+  property("assertions (true)") {
+    forAll { (n: Int) =>
+      assertEquals(n * 2, n + n)
+      assertEquals(n * 0, 0)
+    }
+  }
+
+  property("assertions (false)") {
+    forAll { (n: Int) =>
+      assertEquals(n * 1, n)
+      assertEquals(n * n, n)
+      assertEquals(n + 0, n)
+    }
+  }
+
 }
 
 object ScalaCheckFrameworkSuite
     extends FrameworkTest(
       classOf[ScalaCheckFrameworkSuite],
-      s"""|==> success munit.ScalaCheckFrameworkSuite.list concatenation
-          |==> failure munit.ScalaCheckFrameworkSuite.squared -${' '}
+      s"""|==> success munit.ScalaCheckFrameworkSuite.boolean check (true)
+          |==> failure munit.ScalaCheckFrameworkSuite.boolean check (false) - /scala/munit/ScalaCheckFrameworkSuite.scala:19
+          |18:
+          |19:  property("boolean check (false)") {
+          |20:    forAll { (n: Int) =>
+          |
           |Falsified after 0 passed tests.
           |> ARG_0: -1
           |> ARG_0_ORIGINAL: 2147483647
           |==> success munit.ScalaCheckFrameworkSuite.tagged
+          |==> success munit.ScalaCheckFrameworkSuite.assertions (true)
+          |==> failure munit.ScalaCheckFrameworkSuite.assertions (false) - /scala/munit/ScalaCheckFrameworkSuite.scala:41
+          |40:      assertEquals(n * 1, n)
+          |41:      assertEquals(n * n, n)
+          |42:      assertEquals(n + 0, n)
+          |values are not the same
+          |=> Obtained
+          |1
+          |=> Diff (- obtained, + expected)
+          |-1
+          |+-1
+          |
+          |Falsified after 0 passed tests.
+          |> ARG_0: -1
+          |> ARG_0_ORIGINAL: 2147483647
           |""".stripMargin
     )


### PR DESCRIPTION
Previously we only supported writing ScalaCheck properties using boolean expressions (the default ScalaCheck API).

Now we also allow using MUnit assertions in ScalaCheck properties.