### PR TITLE
Add support for Hedgehog property testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -223,8 +223,31 @@ lazy val munitScalacheckJVM = munitScalacheck.jvm
 lazy val munitScalacheckJS = munitScalacheck.js
 lazy val munitScalacheckNative = munitScalacheck.native
 
+lazy val munitHedgehog = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .in(file("munit-hedgehog"))
+  .dependsOn(munit)
+  .settings(
+    moduleName := "munit-hedgehog",
+    sharedSettings,
+    crossScalaVersions := List(scala213, scala212, scala211, dotty),
+    resolvers += "bintray-scala-hedgehog".at("https://dl.bintray.com/hedgehogqa/scala-hedgehog"),
+    libraryDependencies += ("qa.hedgehog" %% "hedgehog-runner" % "97854199ef795a5dfba15478fd9abe66035ddea2").withDottyCompat(scalaVersion.value)
+  )
+  .jvmSettings(
+    skip in publish := customScalaJSVersion.isDefined
+  )
+  .nativeConfigure(sharedNativeConfigure)
+  .nativeSettings(
+    sharedNativeSettings,
+    skip in publish := customScalaJSVersion.isDefined
+  )
+  .jsSettings(sharedJSSettings)
+lazy val munitHedgehogJVM = munitHedgehog.jvm
+lazy val munitHedgehogJS = munitHedgehog.js
+lazy val munitHedgehogNative = munitHedgehog.native
+
 lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
-  .dependsOn(munit, munitScalacheck)
+  .dependsOn(munit, munitScalacheck, munitHedgehog)
   .enablePlugins(BuildInfoPlugin)
   .settings(
     sharedSettings,

--- a/build.sbt
+++ b/build.sbt
@@ -230,8 +230,11 @@ lazy val munitHedgehog = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     moduleName := "munit-hedgehog",
     sharedSettings,
     crossScalaVersions := List(scala213, scala212, scala211, dotty),
-    resolvers += "bintray-scala-hedgehog".at("https://dl.bintray.com/hedgehogqa/scala-hedgehog"),
-    libraryDependencies += ("qa.hedgehog" %% "hedgehog-runner" % "97854199ef795a5dfba15478fd9abe66035ddea2").withDottyCompat(scalaVersion.value)
+    resolvers += "bintray-scala-hedgehog".at(
+      "https://dl.bintray.com/hedgehogqa/scala-hedgehog"
+    ),
+    libraryDependencies += ("qa.hedgehog" %% "hedgehog-runner" % "97854199ef795a5dfba15478fd9abe66035ddea2")
+      .withDottyCompat(scalaVersion.value)
   )
   .jvmSettings(
     skip in publish := customScalaJSVersion.isDefined

--- a/build.sbt
+++ b/build.sbt
@@ -233,7 +233,7 @@ lazy val munitHedgehog = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     resolvers += "bintray-scala-hedgehog".at(
       "https://dl.bintray.com/hedgehogqa/scala-hedgehog"
     ),
-    libraryDependencies += ("qa.hedgehog" %% "hedgehog-runner" % "97854199ef795a5dfba15478fd9abe66035ddea2")
+    libraryDependencies += ("qa.hedgehog" %%% "hedgehog-runner" % "97854199ef795a5dfba15478fd9abe66035ddea2")
       .withDottyCompat(scalaVersion.value)
   )
   .jvmSettings(

--- a/munit-hedgehog/shared/src/main/scala/munit/HedgehogConfig.scala
+++ b/munit-hedgehog/shared/src/main/scala/munit/HedgehogConfig.scala
@@ -1,0 +1,5 @@
+package munit
+
+import hedgehog.core.PropertyConfig
+
+case class HedgehogConfig(config: PropertyConfig) extends Tag("HedgehogConfig")

--- a/munit-hedgehog/shared/src/main/scala/munit/HedgehogFailException.scala
+++ b/munit-hedgehog/shared/src/main/scala/munit/HedgehogFailException.scala
@@ -19,16 +19,16 @@ object HedgehogFailException {
       case Failed(shrinks, log) =>
         val coverage = Test.renderCoverage(report.coverage, report.tests)
         val message = render(
-            s"Falsified after ${report.tests.value} passed tests and ${shrinks.value} shrinks using seed ${seed}",
-            log.map(Test.renderLog) ++ coverage
-          )
+          s"Falsified after ${report.tests.value} passed tests and ${shrinks.value} shrinks using seed ${seed}",
+          log.map(Test.renderLog) ++ coverage
+        )
         Some(new HedgehogFailException(message, report, seed))
       case GaveUp =>
         val coverage = Test.renderCoverage(report.coverage, report.tests)
         val message = render(
-            s"Gave up after ${report.tests.value} passed tests using seed value $seed. ${report.discards.value} were discarded",
-            coverage
-          )
+          s"Gave up after ${report.tests.value} passed tests using seed value $seed. ${report.discards.value} were discarded",
+          coverage
+        )
         Some(new HedgehogFailException(message, report, seed))
     }
   }

--- a/munit-hedgehog/shared/src/main/scala/munit/HedgehogFailException.scala
+++ b/munit-hedgehog/shared/src/main/scala/munit/HedgehogFailException.scala
@@ -1,0 +1,38 @@
+package munit
+
+import scala.util.control.NoStackTrace
+
+import hedgehog.core.Report
+import hedgehog.core.{Failed, GaveUp, OK}
+import hedgehog.runner.Test
+
+class HedgehogFailException(message: String, val report: Report, val seed: Long)
+    extends Exception(message)
+    with NoStackTrace
+
+object HedgehogFailException {
+
+  def fromReport(report: Report, seed: Long): Option[HedgehogFailException] = {
+    report.status match {
+      case OK =>
+        None
+      case Failed(shrinks, log) =>
+        val coverage = Test.renderCoverage(report.coverage, report.tests)
+        val message = render(
+            s"Falsified after ${report.tests.value} passed tests and ${shrinks.value} shrinks using seed ${seed}",
+            log.map(Test.renderLog) ++ coverage
+          )
+        Some(new HedgehogFailException(message, report, seed))
+      case GaveUp =>
+        val coverage = Test.renderCoverage(report.coverage, report.tests)
+        val message = render(
+            s"Gave up after ${report.tests.value} passed tests using seed value $seed. ${report.discards.value} were discarded",
+            coverage
+          )
+        Some(new HedgehogFailException(message, report, seed))
+    }
+  }
+
+  private def render(msg: String, extras: List[String]): String =
+    (msg :: extras.map(e => "> " + e)).mkString("\n")
+}

--- a/munit-hedgehog/shared/src/main/scala/munit/HedgehogFailException.scala
+++ b/munit-hedgehog/shared/src/main/scala/munit/HedgehogFailException.scala
@@ -2,8 +2,7 @@ package munit
 
 import scala.util.control.NoStackTrace
 
-import hedgehog.core.Report
-import hedgehog.core.{Failed, GaveUp, OK}
+import hedgehog.core._
 import hedgehog.runner.Test
 
 class HedgehogFailException(message: String, val report: Report, val seed: Long)
@@ -20,7 +19,7 @@ object HedgehogFailException {
         val coverage = Test.renderCoverage(report.coverage, report.tests)
         val message = render(
           s"Falsified after ${report.tests.value} passed tests and ${shrinks.value} shrinks using seed ${seed}",
-          log.map(Test.renderLog) ++ coverage
+          log.map(renderLog) ++ coverage
         )
         Some(new HedgehogFailException(message, report, seed))
       case GaveUp =>
@@ -35,4 +34,16 @@ object HedgehogFailException {
 
   private def render(msg: String, extras: List[String]): String =
     (msg :: extras.map(e => "> " + e)).mkString("\n")
+
+  // From Hedgehog, but customized to *not* include the stack trace and instead print exception toString
+  private def renderLog(log: Log): String = {
+    log match {
+      case ForAll(name, value) =>
+        s"${name.value}: $value"
+      case Info(value) =>
+        value
+      case Error(e) =>
+        e.toString
+    }
+  }
 }

--- a/munit-hedgehog/shared/src/main/scala/munit/HedgehogSuite.scala
+++ b/munit-hedgehog/shared/src/main/scala/munit/HedgehogSuite.scala
@@ -4,6 +4,8 @@ import hedgehog._
 import hedgehog.core.{PropertyConfig, PropertyT, Seed}
 import hedgehog.predef.Monad
 
+import munit.internal.Compat._
+
 /**
   * Provides the ability to write property based tests using the Hedgehog library.
   * 
@@ -31,12 +33,12 @@ trait HedgehogSuite extends FunSuite {
   lazy val propertySeed: Long = System.currentTimeMillis()
 
   def property(
-      name: String,
+      name: String
   )(prop: PropertyT[Result])(implicit loc: Location): Unit =
     property(name, propertyConfig)(prop)
 
   def property(
-      options: TestOptions,
+      options: TestOptions
   )(prop: PropertyT[Result])(implicit loc: Location): Unit =
     property(options, propertyConfig)(prop)
 
@@ -53,12 +55,12 @@ trait HedgehogSuite extends FunSuite {
     test(options)(check(prop, config, propertySeed))
 
   def propertyF[F[_]: Monad](
-      name: String,
+      name: String
   )(prop: PropertyT[F[Result]])(implicit loc: Location): Unit =
     propertyF(name, propertyConfig)(prop)
 
   def propertyF[F[_]: Monad](
-      options: TestOptions,
+      options: TestOptions
   )(prop: PropertyT[F[Result]])(implicit loc: Location): Unit =
     propertyF(options, propertyConfig)(prop)
 
@@ -109,5 +111,5 @@ trait HedgehogSuite extends FunSuite {
   /**
     * Supports writing properties with munit assertions instead of Hedgehog `Result`s.
     */
-  implicit def unitToResult: Unit => Result = _ => Result.success
+  implicit val unitToResult: Conversion[Unit, Result] = _=> Result.Success
 }

--- a/munit-hedgehog/shared/src/main/scala/munit/HedgehogSuite.scala
+++ b/munit-hedgehog/shared/src/main/scala/munit/HedgehogSuite.scala
@@ -1,0 +1,113 @@
+package munit
+
+import hedgehog._
+import hedgehog.core.{PropertyConfig, PropertyT, Seed}
+import hedgehog.predef.Monad
+
+/**
+  * Provides the ability to write property based tests using the Hedgehog library.
+  * 
+  * Properties are defined by calling one of the various `property` or `propertyF`
+  * methods and passing a `PropertyT[Result]` or `PropertyT[F[Result]]` respectively.
+  * For example:
+  * {{{
+  * property("additive identity") {
+  *   Gen.int(Range.linearFrom(0, Int.MinValue, Int.MaxValue)).forAll.map { n =>
+  *     assertEquals(n + 0, n)
+  *   }
+  * }
+  * }}}
+  * 
+  * Note both Hedgehog `Result` and munit assertions are supported.
+  */
+trait HedgehogSuite extends FunSuite {
+
+  /**
+   * Provides the default configuration for running property tests.
+   * This can be overriden to change the default or can be changed on
+   * a test-by-test basis by using an overload of `property` and `propertyF`.
+   */
+  lazy val propertyConfig: PropertyConfig = PropertyConfig.default
+  lazy val propertySeed: Long = System.currentTimeMillis()
+
+  def property(
+      name: String,
+  )(prop: PropertyT[Result])(implicit loc: Location): Unit =
+    property(name, propertyConfig)(prop)
+
+  def property(
+      options: TestOptions,
+  )(prop: PropertyT[Result])(implicit loc: Location): Unit =
+    property(options, propertyConfig)(prop)
+
+  def property(
+      name: String,
+      config: PropertyConfig
+  )(prop: PropertyT[Result])(implicit loc: Location): Unit =
+    property(new TestOptions(name, Set.empty, loc), config)(prop)
+
+  def property(
+      options: TestOptions,
+      config: PropertyConfig
+  )(prop: PropertyT[Result])(implicit loc: Location): Unit =
+    test(options)(check(prop, config, propertySeed))
+
+  def propertyF[F[_]: Monad](
+      name: String,
+  )(prop: PropertyT[F[Result]])(implicit loc: Location): Unit =
+    propertyF(name, propertyConfig)(prop)
+
+  def propertyF[F[_]: Monad](
+      options: TestOptions,
+  )(prop: PropertyT[F[Result]])(implicit loc: Location): Unit =
+    propertyF(options, propertyConfig)(prop)
+
+  def propertyF[F[_]: Monad](
+      name: String,
+      config: PropertyConfig
+  )(prop: PropertyT[F[Result]])(implicit loc: Location): Unit =
+    propertyF(new TestOptions(name, Set.empty, loc), config)(prop)
+
+  def propertyF[F[_]: Monad](
+      options: TestOptions,
+      config: PropertyConfig
+  )(prop: PropertyT[F[Result]])(implicit loc: Location): Unit =
+    test(options)(checkF(prop, config, propertySeed))
+
+  /**
+    * Checks the supplied `Property[Result]`, throwing a `HedgehogFailException`
+    * if the property was falsified.
+    */
+  def check(
+      prop: PropertyT[Result],
+      config: PropertyConfig = propertyConfig,
+      seed: Long = propertySeed
+  )(implicit loc: Location): Unit = {
+    val report = Property.check(config, prop, Seed.fromLong(seed))
+    HedgehogFailException.fromReport(report, seed) match {
+      case None => ()
+      case Some(t) => throw t
+    }
+  }
+
+  /**
+    * Checks the supplied `PropertyT[F[Result]]`, throwing a `HedgehogFailException`
+    * if the property was falsified.
+    * 
+    * Note: the exception is thrown within a call to `map` on the effect type. Hence,
+    * this should only be used with effect types that handle exceptions thrown from
+    * `map`.
+    */
+  def checkF[F[_]: Monad](
+      prop: PropertyT[F[Result]],
+      config: PropertyConfig = propertyConfig,
+      seed: Long = propertySeed
+  )(implicit loc: Location): F[Unit] = {
+    ??? // Waiting for https://github.com/hedgehogqa/scala-hedgehog/pull/147
+  }
+
+  /**
+    * Supports writing properties with munit assertions instead of Hedgehog `Result`s.
+    */
+  implicit def unitToResult: Unit => Result = _ => Result.success
+}

--- a/munit-hedgehog/shared/src/main/scala/munit/HedgehogSuite.scala
+++ b/munit-hedgehog/shared/src/main/scala/munit/HedgehogSuite.scala
@@ -7,21 +7,21 @@ import hedgehog.predef.Monad
 import munit.internal.Compat._
 
 /**
-  * Provides the ability to write property based tests using the Hedgehog library.
-  * 
-  * Properties are defined by calling one of the various `property` or `propertyF`
-  * methods and passing a `PropertyT[Result]` or `PropertyT[F[Result]]` respectively.
-  * For example:
-  * {{{
-  * property("additive identity") {
-  *   Gen.int(Range.linearFrom(0, Int.MinValue, Int.MaxValue)).forAll.map { n =>
-  *     assertEquals(n + 0, n)
-  *   }
-  * }
-  * }}}
-  * 
-  * Note both Hedgehog `Result` and munit assertions are supported.
-  */
+ * Provides the ability to write property based tests using the Hedgehog library.
+ *
+ * Properties are defined by calling one of the various `property` or `propertyF`
+ * methods and passing a `PropertyT[Result]` or `PropertyT[F[Result]]` respectively.
+ * For example:
+ * {{{
+ * property("additive identity") {
+ *   Gen.int(Range.linearFrom(0, Int.MinValue, Int.MaxValue)).forAll.map { n =>
+ *     assertEquals(n + 0, n)
+ *   }
+ * }
+ * }}}
+ *
+ * Note both Hedgehog `Result` and munit assertions are supported.
+ */
 trait HedgehogSuite extends FunSuite {
 
   /**
@@ -77,9 +77,9 @@ trait HedgehogSuite extends FunSuite {
     test(options)(checkF(prop, config, propertySeed))
 
   /**
-    * Checks the supplied `Property[Result]`, throwing a `HedgehogFailException`
-    * if the property was falsified.
-    */
+   * Checks the supplied `Property[Result]`, throwing a `HedgehogFailException`
+   * if the property was falsified.
+   */
   def check(
       prop: PropertyT[Result],
       config: PropertyConfig = propertyConfig,
@@ -87,19 +87,19 @@ trait HedgehogSuite extends FunSuite {
   )(implicit loc: Location): Unit = {
     val report = Property.check(config, prop, Seed.fromLong(seed))
     HedgehogFailException.fromReport(report, seed) match {
-      case None => ()
+      case None    => ()
       case Some(t) => throw t
     }
   }
 
   /**
-    * Checks the supplied `PropertyT[F[Result]]`, throwing a `HedgehogFailException`
-    * if the property was falsified.
-    * 
-    * Note: the exception is thrown within a call to `map` on the effect type. Hence,
-    * this should only be used with effect types that handle exceptions thrown from
-    * `map`.
-    */
+   * Checks the supplied `PropertyT[F[Result]]`, throwing a `HedgehogFailException`
+   * if the property was falsified.
+   *
+   * Note: the exception is thrown within a call to `map` on the effect type. Hence,
+   * this should only be used with effect types that handle exceptions thrown from
+   * `map`.
+   */
   def checkF[F[_]: Monad](
       prop: PropertyT[F[Result]],
       config: PropertyConfig = propertyConfig,
@@ -109,7 +109,7 @@ trait HedgehogSuite extends FunSuite {
   }
 
   /**
-    * Supports writing properties with munit assertions instead of Hedgehog `Result`s.
-    */
-  implicit val unitToResult: Conversion[Unit, Result] = _=> Result.Success
+   * Supports writing properties with munit assertions instead of Hedgehog `Result`s.
+   */
+  implicit val unitToResult: Conversion[Unit, Result] = _ => Result.Success
 }

--- a/munit/shared/src/main/scala-2.13/munit/internal/Compat.scala
+++ b/munit/shared/src/main/scala-2.13/munit/internal/Compat.scala
@@ -7,4 +7,5 @@ object Compat {
     p.productElementNames
   def collectionClassName(i: Iterable[_]): String =
     i.asInstanceOf[{ def collectionClassName: String }].collectionClassName
+  type Conversion[-A, +B] = A => B
 }

--- a/munit/shared/src/main/scala-pre-2.13/munit/internal/Compat.scala
+++ b/munit/shared/src/main/scala-pre-2.13/munit/internal/Compat.scala
@@ -7,4 +7,5 @@ object Compat {
     Iterator.continually("")
   def collectionClassName(i: Iterable[_]): String =
     i.stringPrefix
+  type Conversion[-A, +B] = A => B
 }

--- a/tests/shared/src/main/scala/munit/HedgehogFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/HedgehogFrameworkSuite.scala
@@ -59,10 +59,10 @@ object HedgehogFrameworkSuite
           |==> success munit.HedgehogFrameworkSuite.assertions (true)
           |==> failure munit.HedgehogFrameworkSuite.assertions (false) - Falsified after 0 passed tests and 24 shrinks using seed 123
           |> -1
-          |> munit.FailException: /scala/munit/HedgehogFrameworkSuite.scala:38
-          |37:      assertEquals(n * 1, n)
-          |38:      assertEquals(n * n, n)
-          |39:      assertEquals(n + 0, n)
+          |> munit.FailException: /scala/munit/HedgehogFrameworkSuite.scala:39
+          |38:      assertEquals(n * 1, n)
+          |39:      assertEquals(n * n, n)
+          |40:      assertEquals(n + 0, n)
           |values are not the same
           |=> Obtained
           |1

--- a/tests/shared/src/main/scala/munit/HedgehogFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/HedgehogFrameworkSuite.scala
@@ -5,8 +5,8 @@ import hedgehog.core.SuccessCount
 
 class HedgehogFrameworkSuite extends HedgehogSuite {
 
-  // The default propertySeed changes on each test run so we fix it here so that test failures are always the same
-  override lazy val propertySeed = 123L
+  // The default property seed changes on each test run so we fix it here so that test failures are always the same
+  override val hedgehogSeed = 123L
 
   private val genInt: Gen[Int] =
     Gen.int(Range.linearFrom(0, Int.MinValue, Int.MaxValue))
@@ -42,8 +42,7 @@ class HedgehogFrameworkSuite extends HedgehogSuite {
   }
 
   property(
-    "custom config",
-    config = propertyConfig.copy(testLimit = SuccessCount(1000))
+    "custom config".tag(HedgehogConfig(hedgehogPropertyConfig.copy(testLimit = SuccessCount(1000))))
   ) {
     genInt.forAll.map(n => assertEquals(n + 0, n))
   }

--- a/tests/shared/src/main/scala/munit/HedgehogFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/HedgehogFrameworkSuite.scala
@@ -7,8 +7,9 @@ class HedgehogFrameworkSuite extends HedgehogSuite {
 
   // The default propertySeed changes on each test run so we fix it here so that test failures are always the same
   override lazy val propertySeed = 123L
-  
-  private val genInt: Gen[Int] = Gen.int(Range.linearFrom(0, Int.MinValue, Int.MaxValue))
+
+  private val genInt: Gen[Int] =
+    Gen.int(Range.linearFrom(0, Int.MinValue, Int.MaxValue))
 
   property("result check (true)") {
     for {
@@ -40,7 +41,10 @@ class HedgehogFrameworkSuite extends HedgehogSuite {
     }
   }
 
-  property("custom config", config = propertyConfig.copy(testLimit = SuccessCount(1000))) {
+  property(
+    "custom config",
+    config = propertyConfig.copy(testLimit = SuccessCount(1000))
+  ) {
     genInt.forAll.map(n => assertEquals(n + 0, n))
   }
 }

--- a/tests/shared/src/main/scala/munit/HedgehogFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/HedgehogFrameworkSuite.scala
@@ -1,0 +1,72 @@
+package munit
+
+import hedgehog.{Gen, Range, Result}
+import hedgehog.core.SuccessCount
+
+class HedgehogFrameworkSuite extends HedgehogSuite {
+
+  // The default propertySeed changes on each test run so we fix it here so that test failures are always the same
+  override lazy val propertySeed = 123L
+  
+  private val genInt: Gen[Int] = Gen.int(Range.linearFrom(0, Int.MinValue, Int.MaxValue))
+
+  property("result check (true)") {
+    for {
+      l1 <- Gen.list(genInt, Range.linear(0, 100)).forAll
+      l2 <- Gen.list(genInt, Range.linear(0, 100)).forAll
+    } yield Result.assert(l1.size + l2.size == (l1 ::: l2).size)
+  }
+
+  property("result check (false)") {
+    genInt.forAll.map(n => Result.assert(scala.math.sqrt(n * n) == n))
+  }
+
+  property("tagged".tag(new Tag("a"))) {
+    genInt.forAll.map(n => Result.assert(n + 0 == n))
+  }
+
+  property("assertions (true)") {
+    genInt.forAll.map { n =>
+      assertEquals(n * 2, n + n)
+      assertEquals(n * 0, 0)
+    }
+  }
+
+  property("assertions (false)") {
+    genInt.forAll.map { n =>
+      assertEquals(n * 1, n)
+      assertEquals(n * n, n)
+      assertEquals(n + 0, n)
+    }
+  }
+
+  property("custom config", config = propertyConfig.copy(testLimit = SuccessCount(1000))) {
+    genInt.forAll.map(n => assertEquals(n + 0, n))
+  }
+}
+
+object HedgehogFrameworkSuite
+    extends FrameworkTest(
+      classOf[HedgehogFrameworkSuite],
+      s"""|==> success munit.HedgehogFrameworkSuite.result check (true)
+          |==> failure munit.HedgehogFrameworkSuite.result check (false) - Falsified after 0 passed tests and 24 shrinks using seed 123
+          |> -1
+          |==> success munit.HedgehogFrameworkSuite.tagged
+          |==> success munit.HedgehogFrameworkSuite.assertions (true)
+          |==> failure munit.HedgehogFrameworkSuite.assertions (false) - Falsified after 0 passed tests and 24 shrinks using seed 123
+          |> -1
+          |> munit.FailException: /scala/munit/HedgehogFrameworkSuite.scala:38
+          |37:      assertEquals(n * 1, n)
+          |38:      assertEquals(n * n, n)
+          |39:      assertEquals(n + 0, n)
+          |values are not the same
+          |=> Obtained
+          |1
+          |=> Diff (- obtained, + expected)
+          |-1
+          |+-1
+          |\tat munit.Assertions.fail(Assertions.scala:178)
+          |
+          |==> success munit.HedgehogFrameworkSuite.custom config
+          |""".stripMargin
+    )

--- a/tests/shared/src/main/scala/munit/HedgehogFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/HedgehogFrameworkSuite.scala
@@ -69,8 +69,6 @@ object HedgehogFrameworkSuite
           |=> Diff (- obtained, + expected)
           |-1
           |+-1
-          |\tat munit.Assertions.fail(Assertions.scala:178)
-          |
           |==> success munit.HedgehogFrameworkSuite.custom config
           |""".stripMargin
     )

--- a/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
@@ -7,7 +7,7 @@ class ScalaCheckFrameworkSuite extends ScalaCheckSuite {
 
   // NOTE(gabro): this is needed for making the test output stable for the failed test below.
   // It also serves as a test for overriding these parameters.
-  override def scalaCheckTestParameters =
+  override def scalaCheckTestParameters: org.scalacheck.Test.Parameters =
     super.scalaCheckTestParameters.withInitialSeed(Seed(123L))
 
   property("boolean check (true)") {

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -20,7 +20,8 @@ class FrameworkSuite extends BaseFrameworkSuite {
     TestTransformFrameworkSuite,
     ValueTransformCrashFrameworkSuite,
     ValueTransformFrameworkSuite,
-    ScalaCheckFrameworkSuite
+    ScalaCheckFrameworkSuite,
+    HedgehogFrameworkSuite
   )
   tests.foreach { t =>
     check(t)


### PR DESCRIPTION
Opening this draft PR for feedback on overall API. Besides review comments, this also needs the following updates before merging:
- Hedgehog needs to publish for Scala Native
- Hedgehog PR for effectful properties needs to be merged (https://github.com/hedgehogqa/scala-hedgehog/pull/147)
- Somehow skip Scala.js 0.6 publishing of hedghog project