### PR TITLE
Print property seeds and add docs about reproducing test failures

### DIFF
--- a/docs/integrations/scalacheck.md
+++ b/docs/integrations/scalacheck.md
@@ -137,13 +137,13 @@ You can reproduce this failure by adding this to your suite:
 
 To reproduce the failure you can follow the suggestion to fix the seed:
 
-```scala
-class MySuite extends ScalaCheckSuite {
+```diff
+ class MySuite extends ScalaCheckSuite {
 
-  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
++  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
 
-  // ...
-}
+   // ...
+ }
 ```
 
 Re-running the test will now fail deterministically, which allows you to work on

--- a/docs/integrations/scalacheck.md
+++ b/docs/integrations/scalacheck.md
@@ -117,6 +117,33 @@ class IntegerSuite extends ScalaCheckSuite {
 }
 ```
 
+## Reproducing a property failure
+
+In some cases, you may find that ScalaCheck properties fail
+non-deterministically. This can happen due to the randomness of the input values
+for each test run.
+
+When this happens, you can deterministally reproduce a property failure by using
+its seed. MUnit prints the property seed whenever a failure occurs in the form
+of:
+
+```
+Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
+```
+
+To reproduce the exact same failure, you can override the test parameters and
+provide the offending seed as the initial seed:
+
+```scala
+  override def scalaCheckTestParameters =
+    super.scalaCheckTestParameters.withInitialSeed(
+      "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
+    )
+```
+
+Re-running the test will now fail deterministically, which allows you to work on
+an appropriate fix without worrying about randomness.
+
 ## Migrating from ScalaTest
 
 ScalaTest provides two styles for writing property-based tests, which are both

--- a/docs/integrations/scalacheck.md
+++ b/docs/integrations/scalacheck.md
@@ -124,21 +124,26 @@ non-deterministically. This can happen due to the randomness of the input values
 for each test run.
 
 When this happens, you can deterministally reproduce a property failure by using
-its seed. MUnit prints the property seed whenever a failure occurs in the form
-of:
+its seed. Whenever a failure occurs, MUnit prints the offending seed along with
+a suggestion on how to reproduce it:
 
 ```
 Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
+You can reproduce this failure by adding this to your suite:
+
+  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
+
 ```
 
-To reproduce the exact same failure, you can override the test parameters and
-provide the offending seed as the initial seed:
+To reproduce the failure you can follow the suggestion to fix the seed:
 
 ```scala
-  override def scalaCheckTestParameters =
-    super.scalaCheckTestParameters.withInitialSeed(
-      "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
-    )
+class MySuite extends ScalaCheckSuite {
+
+  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
+
+  // ...
+}
 ```
 
 Re-running the test will now fail deterministically, which allows you to work on

--- a/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
@@ -5,11 +5,9 @@ import org.scalacheck.Prop.forAll
 class ScalaCheckFrameworkSuite extends ScalaCheckSuite {
 
   // NOTE(gabro): this is needed for making the test output stable for the failed test below.
-  // It also serves as a test for overriding these parameters.
-  override def scalaCheckTestParameters =
-    super.scalaCheckTestParameters.withInitialSeed(
-      "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
-    )
+  // It also serves as a test for overriding this parameter
+  override val scalaCheckInitialSeed =
+    "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
 
   property("boolean check (true)") {
     forAll { (l1: List[Int], l2: List[Int]) =>
@@ -46,22 +44,25 @@ object ScalaCheckFrameworkSuite
     extends FrameworkTest(
       classOf[ScalaCheckFrameworkSuite],
       """|==> success munit.ScalaCheckFrameworkSuite.boolean check (true)
-         |==> failure munit.ScalaCheckFrameworkSuite.boolean check (false) - /scala/munit/ScalaCheckFrameworkSuite.scala:20
-         |19:
-         |20:  property("boolean check (false)") {
-         |21:    forAll { (n: Int) => scala.math.sqrt(n * n) == n }
+         |==> failure munit.ScalaCheckFrameworkSuite.boolean check (false) - /scala/munit/ScalaCheckFrameworkSuite.scala:18
+         |17:
+         |18:  property("boolean check (false)") {
+         |19:    forAll { (n: Int) => scala.math.sqrt(n * n) == n }
          |
          |Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
+         |You can reproduce this failure by adding this to your suite:
+         |
+         |  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
          |
          |Falsified after 0 passed tests.
          |> ARG_0: -1
          |> ARG_0_ORIGINAL: 2147483647
          |==> success munit.ScalaCheckFrameworkSuite.tagged
          |==> success munit.ScalaCheckFrameworkSuite.assertions (true)
-         |==> failure munit.ScalaCheckFrameworkSuite.assertions (false) - /scala/munit/ScalaCheckFrameworkSuite.scala:38
-         |37:      assertEquals(n * 1, n)
-         |38:      assertEquals(n * n, n)
-         |39:      assertEquals(n + 0, n)
+         |==> failure munit.ScalaCheckFrameworkSuite.assertions (false) - /scala/munit/ScalaCheckFrameworkSuite.scala:36
+         |35:      assertEquals(n * 1, n)
+         |36:      assertEquals(n * n, n)
+         |37:      assertEquals(n + 0, n)
          |values are not the same
          |=> Obtained
          |1
@@ -70,6 +71,9 @@ object ScalaCheckFrameworkSuite
          |+-1
          |
          |Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
+         |You can reproduce this failure by adding this to your suite:
+         |
+         |  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
          |
          |Falsified after 0 passed tests.
          |> ARG_0: -1

--- a/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
@@ -1,14 +1,15 @@
 package munit
 
 import org.scalacheck.Prop.forAll
-import org.scalacheck.rng.Seed
 
 class ScalaCheckFrameworkSuite extends ScalaCheckSuite {
 
   // NOTE(gabro): this is needed for making the test output stable for the failed test below.
   // It also serves as a test for overriding these parameters.
   override def scalaCheckTestParameters =
-    super.scalaCheckTestParameters.withInitialSeed(Seed(123L))
+    super.scalaCheckTestParameters.withInitialSeed(
+      "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
+    )
 
   property("boolean check (true)") {
     forAll { (l1: List[Int], l2: List[Int]) =>
@@ -45,26 +46,30 @@ object ScalaCheckFrameworkSuite
     extends FrameworkTest(
       classOf[ScalaCheckFrameworkSuite],
       """|==> success munit.ScalaCheckFrameworkSuite.boolean check (true)
-         |==> failure munit.ScalaCheckFrameworkSuite.boolean check (false) - /scala/munit/ScalaCheckFrameworkSuite.scala:19
-         |18:
-         |19:  property("boolean check (false)") {
-         |20:    forAll { (n: Int) => scala.math.sqrt(n * n) == n }
+         |==> failure munit.ScalaCheckFrameworkSuite.boolean check (false) - /scala/munit/ScalaCheckFrameworkSuite.scala:20
+         |19:
+         |20:  property("boolean check (false)") {
+         |21:    forAll { (n: Int) => scala.math.sqrt(n * n) == n }
+         |
+         |Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
          |
          |Falsified after 0 passed tests.
          |> ARG_0: -1
          |> ARG_0_ORIGINAL: 2147483647
          |==> success munit.ScalaCheckFrameworkSuite.tagged
          |==> success munit.ScalaCheckFrameworkSuite.assertions (true)
-         |==> failure munit.ScalaCheckFrameworkSuite.assertions (false) - /scala/munit/ScalaCheckFrameworkSuite.scala:37
-         |36:      assertEquals(n * 1, n)
-         |37:      assertEquals(n * n, n)
-         |38:      assertEquals(n + 0, n)
+         |==> failure munit.ScalaCheckFrameworkSuite.assertions (false) - /scala/munit/ScalaCheckFrameworkSuite.scala:38
+         |37:      assertEquals(n * 1, n)
+         |38:      assertEquals(n * n, n)
+         |39:      assertEquals(n + 0, n)
          |values are not the same
          |=> Obtained
          |1
          |=> Diff (- obtained, + expected)
          |-1
          |+-1
+         |
+         |Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
          |
          |Falsified after 0 passed tests.
          |> ARG_0: -1


### PR DESCRIPTION
Previously we would not print seeds when a property would fail, so it would be impossible to deterministically reproduce a failure.
Now we print the seed when a property fails and we added docs to explain how to reproduce failures