### PR TITLE
Add async setup/teardown support to FunFixture

### DIFF
--- a/docs/fixtures.md
+++ b/docs/fixtures.md
@@ -16,7 +16,7 @@ resources after a test case.
 ```scala mdoc:reset
 import java.nio.file._
 class FunFixtureSuite extends munit.FunSuite {
-  val files = new FunFixture[Path](
+  val files = FunFixture[Path](
     setup = { test =>
       Files.createTempFile("tmp", test.name)
     },

--- a/munit/shared/src/main/scala-2.11/munit/internal/FutureCompat.scala
+++ b/munit/shared/src/main/scala-2.11/munit/internal/FutureCompat.scala
@@ -18,5 +18,12 @@ object FutureCompat {
       f.onComplete { t => p.complete(fn(t)) }
       p.future
     }
+    def transformWithCompat[B](
+        fn: Try[T] => Future[B]
+    )(implicit ec: ExecutionContext): Future[B] = {
+      val p = Promise[B]()
+      f.onComplete { t => p.completeWith(fn(t)) }
+      p.future
+    }
   }
 }

--- a/munit/shared/src/main/scala-post-2.11/munit/internal/FutureCompat.scala
+++ b/munit/shared/src/main/scala-post-2.11/munit/internal/FutureCompat.scala
@@ -15,5 +15,10 @@ object FutureCompat {
     )(implicit ec: ExecutionContext): Future[B] = {
       f.transform(fn)
     }
+    def transformWithCompat[B](
+        fn: Try[T] => Future[B]
+    )(implicit ec: ExecutionContext): Future[B] = {
+      f.transformWith(fn)
+    }
   }
 }

--- a/munit/shared/src/main/scala/munit/FunFixtures.scala
+++ b/munit/shared/src/main/scala/munit/FunFixtures.scala
@@ -1,29 +1,56 @@
 package munit
 
+import munit.internal.FutureCompat._
+
+import scala.concurrent.Future
+
 trait FunFixtures { self: FunSuite =>
 
-  class FunFixture[T](
-      val setup: TestOptions => T,
-      val teardown: T => Unit
+  class FunFixture[T] private (
+      val setup: TestOptions => Future[T],
+      val teardown: T => Future[Unit]
   ) {
     def test(options: TestOptions)(
         body: T => Any
     )(implicit loc: Location): Unit = {
       self.test(options) {
-        val argument = setup(options)
-        try body(argument)
-        finally teardown(argument)
+        implicit val ec = munitExecutionContext
+        setup(options).flatMap { argument =>
+          munitValueTransform(body(argument))
+            .transformWithCompat(o =>
+              teardown(argument).transformCompat(_ => o)
+            )
+        }
       }(loc)
     }
   }
+
   object FunFixture {
+    def apply[T](setup: TestOptions => T, teardown: T => Unit) = {
+      implicit val ec = munitExecutionContext
+      async[T](
+        options => Future { setup(options) },
+        argument => Future { teardown(argument) }
+      )
+    }
+    def async[T](setup: TestOptions => Future[T], teardown: T => Future[Unit]) =
+      new FunFixture(setup, teardown)
+
     def map2[A, B](a: FunFixture[A], b: FunFixture[B]): FunFixture[(A, B)] =
-      new FunFixture[(A, B)](
-        setup = { options => (a.setup(options), b.setup(options)) },
+      FunFixture.async[(A, B)](
+        setup = { options =>
+          implicit val ec = munitExecutionContext
+          for {
+            argumentA <- a.setup(options)
+            argumentB <- b.setup(options)
+          } yield (argumentA, argumentB)
+        },
         teardown = {
           case (argumentA, argumentB) =>
-            try a.teardown(argumentA)
-            finally b.teardown(argumentB)
+            implicit val ec = munitExecutionContext
+            Future
+              .sequence(List(a.teardown(argumentA), b.teardown(argumentB)))
+              .map(_ => ())
         }
       )
     def map3[A, B, C](
@@ -33,15 +60,25 @@ trait FunFixtures { self: FunSuite =>
     ): FunFixture[(A, B, C)] =
       new FunFixture[(A, B, C)](
         setup = { options =>
-          (a.setup(options), b.setup(options), c.setup(options))
+          implicit val ec = munitExecutionContext
+          for {
+            argumentA <- a.setup(options)
+            argumentB <- b.setup(options)
+            argumentC <- c.setup(options)
+          } yield (argumentA, argumentB, argumentC)
         },
         teardown = {
           case (argumentA, argumentB, argumentC) =>
-            try a.teardown(argumentA)
-            finally {
-              try b.teardown(argumentB)
-              finally c.teardown(argumentC)
-            }
+            implicit val ec = munitExecutionContext
+            Future
+              .sequence(
+                List(
+                  a.teardown(argumentA),
+                  b.teardown(argumentB),
+                  c.teardown(argumentC)
+                )
+              )
+              .map(_ => ())
         }
       )
   }

--- a/tests/shared/src/test/scala/munit/AsyncFixtureSuite.scala
+++ b/tests/shared/src/test/scala/munit/AsyncFixtureSuite.scala
@@ -1,0 +1,113 @@
+package munit
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+
+class AsyncFixtureSetupTestTeardownOrderSuite extends FunSuite {
+  val latch = Promise[Unit]
+  var completedFromTest = Option.empty[Boolean]
+  var completedFromTeardown = Option.empty[Boolean]
+
+  val latchOnTeardown = FunFixture.async[String](
+    setup = { test => Future.successful(test.name) },
+    teardown = { name =>
+      implicit val ec = munitExecutionContext
+      Future {
+        completedFromTeardown = Some(latch.trySuccess(()));
+      }
+    }
+  )
+
+  override def afterAll(): Unit = {
+    assertEquals(completedFromTest, Some(true))
+    assertEquals(completedFromTeardown, Some(false))
+  }
+
+  latchOnTeardown.test("test is ran before the teardown") { _ =>
+    import scala.concurrent.ExecutionContext.Implicits.global
+    Future {
+      // Ideally we would simulate some work here, for example by using Thread.sleep(50),
+      // which would increase the certainty that this test passes by design and not by lucky
+      // scheduling. However Thread.sleep is not scala-native compatible.
+      //Thread.sleep(50)
+      completedFromTest = Some(latch.trySuccess(()))
+    }
+  }
+}
+
+class AsyncFixtureTeardownSuite extends FunSuite {
+  @volatile var cleanedUp: Boolean = _
+
+  val cleanupInTeardown = FunFixture.async[Unit](
+    _ => { cleanedUp = false; Future.successful(()) },
+    _ => { cleanedUp = true; Future.successful(()) }
+  )
+
+  override def afterAll(): Unit = {
+    assert(cleanedUp)
+  }
+
+  cleanupInTeardown.test("calls teardown when test throws".fail) { _ =>
+    throw new Error("failure in test")
+  }
+
+  cleanupInTeardown.test("calls teardown when test returns failed Future".fail) {
+    _ => Future.failed(new Error("failure in test"))
+  }
+}
+
+class AsyncFixtureSuite extends FunSuite {
+  def asyncFixture[T](setup: () => Future[T], teardown: T => Future[Unit]) =
+    FunFixture.async[T](
+      _ => setup(),
+      teardown
+    )
+
+  val failingSetup = asyncFixture[Unit](
+    () => Future.failed(new Error("failure in setup")),
+    _ => Future.successful(())
+  )
+
+  val failingTeardown = asyncFixture[Unit](
+    () => Future.successful(()),
+    _ => Future.failed(new Error("failure in teardown"))
+  )
+
+  val unitFixture = asyncFixture[Unit](
+    () => Future.successful(()),
+    _ => Future.successful(())
+  )
+
+  failingSetup
+    .test("fail when setup fails".fail) { _ =>
+      fail("failing setup did not fail the test")
+    }
+
+  failingTeardown.test("fail when teardown fails".fail) { _ =>
+    fail("failing teardown did not fail the test")
+  }
+
+  FunFixture
+    .map2(unitFixture, failingSetup)
+    .test("fail when mapped setup fails".fail) { _ =>
+      fail("failing setup did not fail the test")
+    }
+
+  FunFixture
+    .map3(unitFixture, unitFixture, failingSetup)
+    .test("fail when even more nested mapped setup fails".fail) { _ =>
+      fail("failing setup did not fail the test")
+    }
+
+  FunFixture
+    .map2(unitFixture, failingTeardown)
+    .test("fail when mapped teardown fails".fail) { _ =>
+      fail("failing teardown did not fail the test")
+    }
+
+  FunFixture
+    .map3(unitFixture, unitFixture, failingTeardown)
+    .test("fail when even more nested mapped teardown fails".fail) { _ =>
+      fail("failing teardown did not fail the test")
+    }
+}

--- a/tests/shared/src/test/scala/munit/FunFixtureSuite.scala
+++ b/tests/shared/src/test/scala/munit/FunFixtureSuite.scala
@@ -2,7 +2,7 @@ package munit
 
 class FunFixtureSuite extends FunSuite {
   var tearDownName = ""
-  val files = new FunFixture[String](
+  val files = FunFixture[String](
     setup = { test => test.name + "-setup" },
     teardown = { name => tearDownName = name }
   )


### PR DESCRIPTION
FunFixture is now implemented using Future under the hood. Current sync
FunFixture is supported by having a factory method in the companion
object that wraps setup and teardown results to a Future.

Creating sync FunFixture using a factory method instead of constructor
is a backwards incompatible change:

```
new FunFixture[...](...) => FunFixture[...](...)
```