### PR TITLE
Add support for Dotty 0.23.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ val scalaNativeVersion = "0.4.0-M2"
 def scala213 = "2.13.2"
 def scala212 = "2.12.11"
 def scala211 = "2.11.12"
-def dotty = "0.24.0-RC1"
-def dottyLegacy = "0.23.0"
+def dottyNext = "0.24.0-RC1"
+def dottyStable = "0.23.0"
 def junitVersion = "4.13"
 def gcp = "com.google.cloud" % "google-cloud-storage" % "1.107.0"
 inThisBuild(
@@ -57,7 +57,7 @@ addCommandAlias(
 )
 val isPreScala213 = Set[Option[(Long, Long)]](Some((2, 11)), Some((2, 12)))
 val scala2Versions = List(scala211, scala212, scala213)
-val scala3Versions = List(dotty, dottyLegacy)
+val scala3Versions = List(dottyStable, dottyNext)
 val scalaVersions = scala2Versions ++ scala3Versions
 def isNotScala211(v: Option[(Long, Long)]): Boolean = !v.contains((2, 11))
 def isScala2(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2)

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ def scala213 = "2.13.2"
 def scala212 = "2.12.11"
 def scala211 = "2.11.12"
 def dotty = "0.24.0-RC1"
+def dottyLegacy = "0.23.0"
 def junitVersion = "4.13"
 def gcp = "com.google.cloud" % "google-cloud-storage" % "1.107.0"
 inThisBuild(
@@ -56,7 +57,8 @@ addCommandAlias(
 )
 val isPreScala213 = Set[Option[(Long, Long)]](Some((2, 11)), Some((2, 12)))
 val scala2Versions = List(scala211, scala212, scala213)
-val scalaVersions = scala2Versions ++ List(dotty)
+val scala3Versions = List(dotty, dottyLegacy)
+val scalaVersions = scala2Versions ++ scala3Versions
 def isNotScala211(v: Option[(Long, Long)]): Boolean = !v.contains((2, 11))
 def isScala2(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2)
 def isScala3(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 0)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,12 +27,13 @@ libraryDependencies += "org.scalameta" %% "munit" % "@VERSION@" % Test
 testFrameworks += new TestFramework("munit.Framework")
 ```
 
-| Scala Version   | JVM | Scala.js (0.6.x, 1.x) | Native (0.4.x) |
-| --------------- | :-: | :-------------------: | :------------: |
-| 2.11.x          | ✅  |          ✅           |       ✅       |
-| 2.12.x          | ✅  |          ✅           |      n/a       |
-| 2.13.x          | ✅  |          ✅           |      n/a       |
-| @DOTTY_VERSION@ | ✅  |          n/a          |      n/a       |
+| Scala Version          | JVM | Scala.js (0.6.x, 1.x) | Native (0.4.x) |
+| ---------------------- | :-: | :-------------------: | :------------: |
+| 2.11.x                 | ✅  |          ✅           |       ✅       |
+| 2.12.x                 | ✅  |          ✅           |      n/a       |
+| 2.13.x                 | ✅  |          ✅           |      n/a       |
+| @DOTTY_NEXT_VERSION@   | ✅  |          n/a          |      n/a       |
+| @DOTTY_STABLE_VERSION@ | ✅  |          n/a          |      n/a       |
 
 Next, write a test suite.
 

--- a/tests/shared/src/test/scala/munit/TypeCheckSuite.scala
+++ b/tests/shared/src/test/scala/munit/TypeCheckSuite.scala
@@ -57,6 +57,14 @@ class TypeCheckSuite extends FunSuite {
                 |val x: = 2
                 |       ^
                 |""".stripMargin,
+      "0.23.0" ->
+        """|error: an identifier expected, but eof found
+           |val x: = 2
+           |      ^
+           |error: Declaration of value x not allowed here: only classes can have declared but undefined members
+           |package munit
+           |   ^
+           |""".stripMargin,
       "3" ->
         // NOTE(olafur): I'm not sure what's going on with the second errors but
         // that's what Dotty reports.


### PR DESCRIPTION
Previously, we only built against the latest Dotty release candidate. Now, we
build against both the release candidate and the latest stable release.