### PR TITLE
Runner: Fix Scala.js linking error

### DIFF
--- a/munit/non-jvm/src/main/scala/org/junit/runner/Runner.scala
+++ b/munit/non-jvm/src/main/scala/org/junit/runner/Runner.scala
@@ -2,7 +2,7 @@ package org.junit.runner
 
 import org.junit.runner.notification.RunNotifier
 
-trait Runner {
+abstract class Runner {
   def run(notifier: RunNotifier): Unit
   def getDescription(): Description
 }


### PR DESCRIPTION
When the libraries `scalajs-test-interface` and `scalajs-junit-test-runtime` are placed before MUnit in the classpath, the following linking error occurs:

```
org.junit.runner.Runner (of kind Class) is not a valid interface
implemented by munit.MUnitRunner (of kind Class)
```

Solve this by defining an `abstract class` instead of a `trait` to match JUnit's [`Runner`](https://junit.org/junit4/javadoc/4.12/org/junit/runner/Runner.html).

See also #114.