### PR TITLE
Preserve stack trace of unexpected exceptions in ScalaCheckSuite

### DIFF
--- a/docs/integrations/scalacheck.md
+++ b/docs/integrations/scalacheck.md
@@ -129,7 +129,7 @@ a suggestion on how to reproduce it:
 
 ```
 Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
-You can reproduce this failure by adding this to your suite:
+You can reproduce this failure by adding the following override to your suite:
 
   override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
 

--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -57,13 +57,13 @@ trait ScalaCheckSuite extends FunSuite {
       scalaCheckTestParameters,
       Prop(genParams => prop(genParams.withInitialSeed(seed)))
     )
-    def renderResult(r: Result) = {
+    def renderResult(r: Result): String = {
       val resultMessage = Pretty.pretty(r, scalaCheckPrettyParameters)
       if (r.passed) {
         resultMessage
       } else {
         val seedMessage = s"""|Failing seed: ${seed.toBase64}
-                              |You can reproduce this failure by adding this to your suite:
+                              |You can reproduce this failure by adding the following override to your suite:
                               |
                               |  override val scalaCheckInitialSeed = "${seed.toBase64}"
                               |""".stripMargin

--- a/tests/shared/src/main/scala/munit/ScalaCheckExceptionFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckExceptionFrameworkSuite.scala
@@ -1,0 +1,70 @@
+package munit
+
+import org.scalacheck.Prop
+
+class ScalaCheckExceptionFrameworkSuite extends ScalaCheckSuite {
+  override val scalaCheckInitialSeed =
+    "9WNU_CSZAQwiiPWDlHs4NWI-knIDEKCsgGqdhZgNKnB="
+
+  property("hide my stacks") {
+    Prop.forAll { (i: Int) =>
+      throw new StackOverflowError()
+      Prop(true)
+    }
+  }
+}
+
+// NOTE(olafur): extracted this object into a class to avoid the following error with Dotty
+// ==> X munit.FrameworkSuite.initializationError  0.002s java.lang.VerifyError: Bad type on operand stack
+// Exception Details:
+//   Location:
+//     munit/ScalaCheckExceptionFrameworkSuite$.<init>()V @19: invokedynamic
+//   Reason:
+//     Type uninitializedThis (current frame, stack[0]) is not assignable to 'munit/ScalaCheckExceptionFrameworkSuite$'
+//   Current Frame:
+//     bci: @19
+//     flags: { flagThisUninit }
+//     locals: { uninitializedThis, 'java/lang/Class', 'java/lang/String' }
+//     stack: { uninitializedThis }
+//   Bytecode:
+//     0x0000000: 1210 4cb2 0015 b200 1a12 1cb6 0020 b600
+//     0x0000010: 234d 2aba 0037 0000 4eb2 003c b600 403a
+//     0x0000020: 04b2 003c b600 443a 05b2 003c b600 483a
+//     0x0000030: 062a 2b2c 1904 1905 1906 2dbb 004a 5912
+//     0x0000040: 4c10 33b7 004f b700 522a b300 54b1
+//
+// FrameworkSuite.<init>(FrameworkSuite.scala:30)
+class ScalaCheckExceptionFrameworkSuites
+    extends FrameworkTest(
+      classOf[ScalaCheckExceptionFrameworkSuite],
+      """|munit.ScalaCheckExceptionFrameworkSuite.$anonfun$new$2(ScalaCheckExceptionFrameworkSuite.scala:11)
+         |munit.ScalaCheckExceptionFrameworkSuite.$anonfun$new$2$adapted(ScalaCheckExceptionFrameworkSuite.scala:10)
+         |==> failure munit.ScalaCheckExceptionFrameworkSuite.hide my stacks - Failing seed: 9WNU_CSZAQwiiPWDlHs4NWI-knIDEKCsgGqdhZgNKnB=
+         |You can reproduce this failure by adding the following override to your suite:
+         |
+         |  override val scalaCheckInitialSeed = "9WNU_CSZAQwiiPWDlHs4NWI-knIDEKCsgGqdhZgNKnB="
+         |
+         |Exception raised on property evaluation.
+         |> ARG_0: 0
+         |> ARG_0_ORIGINAL: -860854860
+         |> Exception: java.lang.StackOverflowError: null
+         |""".stripMargin,
+      tags = Set(OnlyJVM),
+      onEvent = { event =>
+        if (event.throwable.isDefined &&
+            event.throwable().get.getCause() != null) {
+          event
+            .throwable()
+            .get
+            .getCause
+            .getStackTrace()
+            .take(2)
+            .mkString("", "\n", "\n")
+        } else {
+          ""
+        }
+      }
+    )
+
+object ScalaCheckExceptionFrameworkSuite
+    extends ScalaCheckExceptionFrameworkSuites

--- a/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
@@ -50,7 +50,7 @@ object ScalaCheckFrameworkSuite
          |19:    forAll { (n: Int) => scala.math.sqrt(n * n) == n }
          |
          |Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
-         |You can reproduce this failure by adding this to your suite:
+         |You can reproduce this failure by adding the following override to your suite:
          |
          |  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
          |
@@ -71,7 +71,7 @@ object ScalaCheckFrameworkSuite
          |+-1
          |
          |Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
-         |You can reproduce this failure by adding this to your suite:
+         |You can reproduce this failure by adding the following override to your suite:
          |
          |  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
          |

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -26,7 +26,8 @@ class FrameworkSuite extends BaseFrameworkSuite {
     DuplicateNameFrameworkSuite,
     FullStackTraceFrameworkSuite,
     SmallStackTraceFrameworkSuite,
-    AssertionsFrameworkSuite
+    AssertionsFrameworkSuite,
+    ScalaCheckExceptionFrameworkSuite
   )
   tests.foreach { t => check(t) }
 }


### PR DESCRIPTION
Previously, stack traces from unexpected exceptions would be swallowed
in ScalaCheckSuite. Now, the stack trace is displayed making it easier
to troubleshoot a test failure.

Unexpected exceptions look like this now
<img width="840" alt="Screenshot 2020-05-13 at 09 04 16" src="https://user-images.githubusercontent.com/1408093/81796803-76dc3080-94fd-11ea-83b7-4ef84f70a07a.png">

Fixes #128 