### PR TITLE
Add support for nested tests via JUnit Description children

### DIFF
--- a/junit-interface/src/main/java/munit/internal/junitinterface/Describe.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/Describe.java
@@ -1,0 +1,5 @@
+package munit.internal.junitinterface;
+
+import java.lang.annotation.Annotation;
+
+public interface Describe {}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
@@ -95,7 +95,7 @@ final class EventDispatcher extends RunListener
     uncapture(true);
     postIfFirst(new ErrorEvent(failure, Status.Failure) {
       void logTo(RichLogger logger) {
-        logger.error( settings.buildTestResult(Status.Failure) +ansiName+" "+ durationSuffix() + " " + ansiMsg, error);
+        logger.error(settings.buildTestResult(failure.getDescription(), Status.Failure) +ansiName+" "+ durationSuffix() + " " + ansiMsg, error);
       }
     });
   }
@@ -107,7 +107,7 @@ final class EventDispatcher extends RunListener
     uncapture(false);
     postIfFirst(new InfoEvent(desc, Status.Success) {
       void logTo(RichLogger logger) {
-        logger.info(settings.buildTestResult(Status.Success) +Ansi.c(desc.getMethodName(), SUCCESS1) + durationSuffix());
+        logger.info(settings.buildTestResult(desc, Status.Success) +Ansi.c(desc.getMethodName(), SUCCESS1) + durationSuffix());
       }
     });
     logger.popCurrentTestClassName();
@@ -118,7 +118,7 @@ final class EventDispatcher extends RunListener
   {
     postIfFirst(new InfoEvent(desc, Status.Skipped) {
       void logTo(RichLogger logger) {
-        logger.warn(settings.buildTestResult(Status.Ignored) + ansiName+" ignored" + durationSuffix());
+        logger.warn(settings.buildTestResult(desc, Status.Ignored) + ansiName+" ignored" + durationSuffix());
       }
     });
   }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/Indent.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/Indent.java
@@ -1,0 +1,18 @@
+package munit.internal.junitinterface;
+
+import java.lang.annotation.Annotation;
+
+public class Indent implements Annotation {
+    final int value;
+
+    public Indent(int value) {
+        this.value = value;
+    }
+
+    public int value() { return value; }
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return Indent.class;
+    }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
@@ -14,6 +14,7 @@ import static munit.internal.junitinterface.Ansi.SUCCESS1;
 import static munit.internal.junitinterface.Ansi.SUCCESS2;
 import static munit.internal.junitinterface.Ansi.c;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.*;
 
@@ -133,16 +134,41 @@ class RunSettings implements Settings {
     return buildColoredName(desc, null, null, null);
   }
 
-  String buildTestResult(Status status) {
+  int indent(Description desc) {
+    Indent indent = desc.getAnnotation(Indent.class);
+    if (indent == null) return 2;
+    else return indent.value();
+  }
+
+  String repeat(String what, int count) {
+    StringBuilder out = new StringBuilder(what.length() * count);
+    for (int i = 0; i < count; i ++) {
+      out.append(what);
+    }
+    return out.toString();
+  }
+
+  boolean isDescribe(Description desc) {
+    for (Annotation a : desc.getAnnotations()) {
+        if (a instanceof Describe) {
+          return true;
+        }
+    }
+    return false;
+  }
+
+  String buildTestResult(Description desc, Status status) {
+    int indent = indent(desc);
+    if (isDescribe(desc)) return repeat(" ", indent);
     switch (status) {
         case Success:
-          return c("  + ", SUCCESS1);
+          return c(repeat(" ", indent) + "+ ", SUCCESS1);
         case Ignored:
-          return c("==> i ", SKIPPED);
+          return c(repeat("=", indent) + "> i ", SKIPPED);
         case Skipped:
-          return c("==> s ", SKIPPED);
+          return c(repeat("=", indent) + "> s ", SKIPPED);
         default:
-          return c("==> X ", ERRMSG);
+          return c(repeat("=", indent) + "> X ", ERRMSG);
       }
   }
 

--- a/munit-docs/src/main/scala/docs/MUnitModifier.scala
+++ b/munit-docs/src/main/scala/docs/MUnitModifier.scala
@@ -11,7 +11,6 @@ import scala.collection.mutable
 import scala.collection.JavaConverters._
 import com.google.cloud.storage.Blob
 import java.io.ByteArrayOutputStream
-import munit.sbtmunit.MUnitTestReport
 import com.google.gson.Gson
 import java.nio.charset.StandardCharsets
 import munit.sbtmunit.MUnitTestReport

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/Describe.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/Describe.scala
@@ -1,0 +1,3 @@
+package munit.internal.junitinterface
+
+trait Describe

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/Indent.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/Indent.scala
@@ -1,0 +1,8 @@
+package munit.internal.junitinterface
+
+import java.lang.annotation.Annotation
+
+class Indent(val value: Int) extends Annotation {
+  def annotationType(): Class[_ <: java.lang.annotation.Annotation] =
+    classOf[Indent]
+}

--- a/munit/non-jvm/src/main/scala/org/junit/runner/Description.scala
+++ b/munit/non-jvm/src/main/scala/org/junit/runner/Description.scala
@@ -1,15 +1,17 @@
 package org.junit.runner
 
 import java.lang.annotation.Annotation
+import scala.collection.mutable
 
 class Description(
     cls: Option[Class[_]] = None,
     methodName: Option[String] = None,
     annotations: List[Annotation] = Nil,
-    children: List[Description] = Nil
+    children: mutable.ListBuffer[Description] = mutable.ListBuffer.empty
 ) {
-  def addChild(description: Description): Description =
-    new Description(cls, methodName, annotations, description :: children)
+  def addChild(description: Description): Unit = {
+    children += description
+  }
   def getMethodName: String = methodName.getOrElse("<unknown>")
   def getTestClass: Option[Class[_]] = cls
   def getAnnotations: List[Annotation] = annotations

--- a/munit/shared/src/main/scala/munit/Describe.scala
+++ b/munit/shared/src/main/scala/munit/Describe.scala
@@ -1,0 +1,9 @@
+package munit
+
+sealed class Describe
+    extends Tag("Describe")
+    with munit.internal.junitinterface.Describe
+object Describe extends Describe {
+  override def annotationType(): Class[_ <: java.lang.annotation.Annotation] =
+    classOf[Describe]
+}

--- a/munit/shared/src/main/scala/munit/FunSuite.scala
+++ b/munit/shared/src/main/scala/munit/FunSuite.scala
@@ -24,7 +24,15 @@ abstract class FunSuite
   def munitTests(): Seq[Test] = {
     munitSuiteTransform(munitTestsBuffer.toList)
   }
+  override def munitPollTests(): Seq[Test] = {
+    val result = munitTests()
+    munitTestsBuffer.clear()
+    result
+  }
 
+  def describe(name: String)(body: => Any)(implicit loc: Location): Unit = {
+    test(name.tag(munit.Describe))(body)
+  }
   def test(name: String)(body: => Any)(implicit loc: Location): Unit = {
     test(new TestOptions(name, Set.empty, loc))(body)
   }

--- a/munit/shared/src/main/scala/munit/Suite.scala
+++ b/munit/shared/src/main/scala/munit/Suite.scala
@@ -18,6 +18,8 @@ abstract class Suite extends PlatformSuite {
   /** The base class for all test suites */
   def munitTests(): Seq[Test]
 
+  def munitPollTests(): Seq[Test] = munitTests()
+
   /** Functinonal fixtures that can be reused for individual test cases or entire suites. */
   def munitFixtures: Seq[Fixture[_]] = Nil
 

--- a/tests/shared/src/test/scala/munit/NestedSuite.scala
+++ b/tests/shared/src/test/scala/munit/NestedSuite.scala
@@ -1,0 +1,15 @@
+package munit
+
+class NestedSuite extends BaseSuite {
+  describe("primitives") {
+    describe("positive") {
+      test("positive1") {}
+      test("positive2") {}
+    }
+    describe("negative") {
+      test("negative1") {}
+      test("negative2") {}
+    }
+  }
+
+}


### PR DESCRIPTION
Previously, MUnit only supported declaring tests as a flat list. Now,
  users can organize test cases as a nested tree of test like this.
```scala
class NestedSuite extends munit.FunSuite {
  describe("primitives") {
    describe("positive") {
      test("positive1") {}
      test("positive2") {}
    }
    describe("negative") {
      test("negative1") {}
      test("negative2") {}
    }
  }
}
```

The rendered output of this indents the nested tests like this:
```
munit.NestedSuite:
  primitives 0.054s
    positive 0.001s
      + positive1 0.0s
      + positive2 0.0s
    negative 0.0s
      + negative1 0.0s
      + negative2 0.0s
```

Related issue #93 

cc/ @mpilquist @gzoller 

I'm personally on the fence about introducing this behavior because it's not clear how nested tests interact with

* filtering capabilities: it's technically not possible to run only a nested test, you must run all the parents as well
* fixtures: for example, do we trigger `beforeEach` for every node in the test tree? 

Users can already group related tests via test suites, which provides a better UX for filtering (tab completions in sbt) and it's more self-explanatory how fixtures work (you have hooks before/after each test case and for each test suite)


TODOs

* [ ] Scala.js/Native support
* [ ] Make sure IntelliJ renders nested tests correctly, not as a flat list

![Screenshot 2020-05-24 at 12 38 46](https://user-images.githubusercontent.com/1408093/82754315-97d53900-9dbb-11ea-9c74-f33a01d6705c.png)

