### PR TITLE
Fix #138 - duplicate names with bracket characters

### DIFF
--- a/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
@@ -166,17 +166,8 @@ class RunSettings implements Settings {
     String m = desc.getMethodName();
     if(m != null) {
       b.append('.');
-      int mpos1 = m.lastIndexOf('[');
-      int mpos2 = m.lastIndexOf(']');
-      if(mpos1 == -1 || mpos2 < mpos1) b.append(c(decodeName(m), c2));
-      else {
-        b.append(c(decodeName(m.substring(0, mpos1)), c2));
-        b.append('[');
-        b.append(c(m.substring(mpos1+1, mpos2), c3));
-        b.append(']');
-      }
+      b.append(c(decodeName(m), c2));
     }
-
     return b.toString();
   }
 

--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -63,11 +63,12 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
           .find(candidate => !testNames.contains(candidate))
           .head
         testNames += testName
-        Description.createTestDescription(
+        val desc = Description.createTestDescription(
           cls,
           testName,
           test.annotations: _*
         )
+        desc
       }
     )
   }

--- a/tests/shared/src/main/scala/munit/DuplicateNameFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/DuplicateNameFrameworkSuite.scala
@@ -9,6 +9,9 @@ class DuplicateNameFrameworkSuite extends FunSuite {
   check("a")(() => fail("boom"))
   check("a")(() => fail("boom"))
   check("a")(() => ())
+
+  test("POST -> /[type]/[id]") {}
+  test("POST -> /[type]/[id]") {}
 }
 
 object DuplicateNameFrameworkSuite
@@ -24,5 +27,7 @@ object DuplicateNameFrameworkSuite
          |10:  check("a")(() => fail("boom"))
          |11:  check("a")(() => ())
          |==> success munit.DuplicateNameFrameworkSuite.a-3
+         |==> success munit.DuplicateNameFrameworkSuite.POST -> /[type]/[id]
+         |==> success munit.DuplicateNameFrameworkSuite.POST -> /[type]/[id]-1
          |""".stripMargin
     )


### PR DESCRIPTION
A bug in the JUnit/sbt event handler made it ignore tests when two tests
had the same name AND the name contains a `[` character. This bug is a
relic from the original sbt/junit-interface implementation that assumes
that test names are JVM method names where `[` has special meaning.
This bug was not present in the Scala.js implementation.