### PR TITLE
doc: add a few tips on converting from match-style assertions

### DIFF
--- a/docs/scalatest.md
+++ b/docs/scalatest.md
@@ -31,6 +31,22 @@ improve the error message in failed assertions:
 + assertEquals(a, b)
 ```
 
+Or if you are using match-style assertions via `with Matchers`, change the
+assertions like so:
+
+```diff
+- result shouldEqual Some(Name(first, last))
++ assertEquals(result, Some(Name(first, last)))
+```
+
+MUnit doesn't ship with a large set of assertions, so some fancier matchers will
+have to be converted to a simple assertion:
+
+```diff
+- myList should have size 2
++ assertEquals(myList.length, 2)
+```
+
 If you are coming from `WordSpec` style tests, make sure to flatten them, or your tests
 will not run. (Only the outer test will be selected to run, and the inner tests will do
 nothing).


### PR DESCRIPTION
With this in place, I think MUnit's documentation captures everything I learned during the conversion. I wonder, though, whether it would be worthwhile to make this page a little more self-contained, i.e. what about linking back to other parts of the documentation that are relevant? Part of the reason I say this is because when a teammate of mine original saw this page, he remarked that it was rather sparse. Perhaps it would be nice to be able to have people go straight to a page on converting, and from there be guided to the other parts of the documentation that they should read. If folks like this idea, I can submit another PR against this page with links to other part of the documentation that I found especially necessary during the conversion.