### PR TITLE
add ScalaCheckSuite#include

### DIFF
--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -1,6 +1,6 @@
 package munit
 
-import org.scalacheck.Prop
+import org.scalacheck.{Prop, Properties}
 import org.scalacheck.{Test => ScalaCheckTest}
 import org.scalacheck.util.Pretty
 import org.scalacheck.rng.Seed
@@ -22,6 +22,15 @@ trait ScalaCheckSuite extends FunSuite {
   )(body: => Prop)(implicit loc: Location): Unit = {
     test(options)(body)
   }
+
+  /** Adds all properties from another property collection to this one */
+  def include(ps: Properties): Unit =
+    include(ps, prefix = "")
+
+  /** Adds all properties from another property collection to this one
+   *  with a prefix this is prepended to each included property's name. */
+  def include(ps: Properties, prefix: String): Unit =
+    for ((n, p) <- ps.properties) property(prefix + n)(p)
 
   // Allow property bodies of type Unit
   // This is done to support using MUnit assertions in property bodies

--- a/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
@@ -38,6 +38,16 @@ class ScalaCheckFrameworkSuite extends ScalaCheckSuite {
     }
   }
 
+  include(IntProps)
+  include(IntProps, "Prefix")
+
+}
+
+object IntProps extends org.scalacheck.Properties("Int") {
+  property("associative") =
+    forAll((x: Int, y: Int, z: Int) => x + y + z == x + (y + z))
+  property("commutative") = forAll((x: Int, y: Int) => x + y == y + x)
+  property("identity") = forAll((x: Int) => x + 0 == x)
 }
 
 object ScalaCheckFrameworkSuite
@@ -78,5 +88,11 @@ object ScalaCheckFrameworkSuite
          |Falsified after 0 passed tests.
          |> ARG_0: -1
          |> ARG_0_ORIGINAL: 2147483647
+         |==> success munit.ScalaCheckFrameworkSuite.Int.associative
+         |==> success munit.ScalaCheckFrameworkSuite.Int.commutative
+         |==> success munit.ScalaCheckFrameworkSuite.Int.identity
+         |==> success munit.ScalaCheckFrameworkSuite.PrefixInt.associative
+         |==> success munit.ScalaCheckFrameworkSuite.PrefixInt.commutative
+         |==> success munit.ScalaCheckFrameworkSuite.PrefixInt.identity
          |""".stripMargin
     )


### PR DESCRIPTION
Not sure if this fits here, but it allows us to include tests from an existing ScalaCheck `Properties`, e.g. discipline laws
https://github.com/typelevel/discipline/blob/327ab715dcff99f756fbff2ff75ada2df7d80112/core/src/main/scala/org/typelevel/discipline/Laws.scala#L83