### PR TITLE
Support ScalaTest 3.1+ in `PantsFramework`

### DIFF
--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitComputer.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitComputer.java
@@ -31,7 +31,8 @@ public class JUnitComputer extends Computer {
               testClassLoader.loadClass(runner)
           );
         } catch (ClassNotFoundException e) {
-          e.printStackTrace();
+          // ignore, since we'll fail to find at least one of the 2 `JUnitRunners`
+          // (it moved from `org.scalatest.junit` to `org.scalatestplus.junit` in 3.1)
         }
       });
   }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/PantsFramework.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/PantsFramework.java
@@ -12,11 +12,18 @@ public class PantsFramework extends JUnitFramework {
       "org.scalatest.junit.JUnitRunner"
   );
 
+  // In ScalaTest 3.1+, `JUnitRunner` moved to a different package.
+  private static final CustomFingerprint scalatestPlusJunitFingerprint = CustomFingerprint.of(
+      "org.scalatest.Suite",
+      "org.scalatestplus.junit.JUnitRunner"
+  );
+
   private static final Fingerprint[] FINGERPRINTS = new Fingerprint[] {
       new RunWithFingerprint(),
       new JUnitFingerprint(),
       new JUnit3Fingerprint(),
-      scalatestFingerprint
+      scalatestFingerprint,
+      scalatestPlusJunitFingerprint
   };
 
   @Override
@@ -26,7 +33,7 @@ public class PantsFramework extends JUnitFramework {
 
   @Override
   public CustomRunners customRunners() {
-    return CustomRunners.of(scalatestFingerprint);
+    return CustomRunners.of(scalatestFingerprint, scalatestPlusJunitFingerprint);
   }
 
   @Override


### PR DESCRIPTION
Previously, MUnit's `PantsFramework` would look for ScalaTest's JUnit
runner only in `org.scalatest.junit.JUnitRunner`. In ScalaTest 3.1+,
this class has been moved to `org.scalatestplus.junit.JUnitRunner`.

This commit adds a new Fingerprint to the `PantsFramework`, so that
tests defined with ScalaTest 3.1+ can be detected.