### PR TITLE
Add method overload to avoid warning in FunFixture.

### DIFF
--- a/munit/shared/src/main/scala/munit/FunFixtures.scala
+++ b/munit/shared/src/main/scala/munit/FunFixtures.scala
@@ -11,7 +11,7 @@ trait FunFixtures { self: FunSuite =>
   class FunFixture[T] private (
       val setup: TestOptions => Future[T],
       val teardown: T => Future[Unit]
-  )(implicit dummy: DummyImplicit) {
+  )(implicit dummy: DummyImplicit) { fixture =>
     @deprecated("Use `FunFixture(...)` without `new` instead", "0.7.2")
     def this(setup: TestOptions => T, teardown: T => Unit) =
       this(
@@ -19,6 +19,11 @@ trait FunFixtures { self: FunSuite =>
         (argument: T) => Future(teardown(argument))(munitExecutionContext)
       )
 
+    def test(name: String)(
+        body: T => Any
+    )(implicit loc: Location): Unit = {
+      fixture.test(TestOptions(name))(body)
+    }
     def test(options: TestOptions)(
         body: T => Any
     )(implicit loc: Location): Unit = {

--- a/munit/shared/src/main/scala/munit/FunSuite.scala
+++ b/munit/shared/src/main/scala/munit/FunSuite.scala
@@ -26,7 +26,7 @@ abstract class FunSuite
   }
 
   def test(name: String)(body: => Any)(implicit loc: Location): Unit = {
-    test(new TestOptions(name, Set.empty, loc))(body)
+    test(new TestOptions(name))(body)
   }
   def test(options: TestOptions)(body: => Any)(implicit loc: Location): Unit = {
     munitTestsBuffer += munitTestTransform(

--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -53,7 +53,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
   def createTestDescription(test: suite.Test): Description = {
     descriptions.getOrElseUpdate(
       test, {
-        val escapedName = test.name.replaceAllLiterally("\n", "\\n")
+        val escapedName = test.name.replace("\n", "\\n")
         val testName = munit.internal.Compat.LazyList
           .from(0)
           .map {

--- a/munit/shared/src/main/scala/munit/TestOptions.scala
+++ b/munit/shared/src/main/scala/munit/TestOptions.scala
@@ -12,6 +12,8 @@ final class TestOptions(
     val tags: Set[Tag],
     val location: Location
 ) extends Serializable {
+  def this(name: String)(implicit loc: munit.Location) =
+    this(name, Set.empty, loc)
 
   def withName(newName: String): TestOptions =
     copy(name = newName)
@@ -35,6 +37,11 @@ final class TestOptions(
 
   override def toString: String =
     s"TestOptions($name, $tags, $location)"
+}
+
+object TestOptions extends TestOptionsConversions {
+  def apply(name: String)(implicit loc: munit.Location): TestOptions =
+    new TestOptions(name)
 }
 
 trait TestOptionsConversions {

--- a/munit/shared/src/main/scala/munit/internal/difflib/Diff.scala
+++ b/munit/shared/src/main/scala/munit/internal/difflib/Diff.scala
@@ -105,6 +105,6 @@ class Diff(val obtained: String, val expected: String) extends Serializable {
   }
 
   private def splitIntoLines(string: String): Seq[String] = {
-    string.trim().replaceAllLiterally("\r\n", "\n").split("\n").toIndexedSeq
+    string.trim().replace("\r\n", "\n").split("\n").toIndexedSeq
   }
 }

--- a/tests/shared/src/test/scala/munit/BaseFrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/BaseFrameworkSuite.scala
@@ -20,7 +20,7 @@ abstract class BaseFrameworkSuite extends BaseSuite {
     if (ex.getMessage() == null) "null"
     else {
       ex.getMessage()
-        .replaceAllLiterally(
+        .replace(
           BuildInfo.sourceDirectory.toString(),
           ""
         )
@@ -103,7 +103,7 @@ abstract class BaseFrameworkSuite extends BaseSuite {
         val obtained = AnsiColors.filterAnsi(
           t.format match {
             case SbtFormat =>
-              events.toString().replaceAllLiterally("\"\"\"", "'''")
+              events.toString().replace("\"\"\"", "'''")
             case StdoutFormat =>
               elapsedTimePattern.matcher(stdout).replaceAll(" <elapsed time>")
           }

--- a/tests/shared/src/test/scala/munit/LinesSuite.scala
+++ b/tests/shared/src/test/scala/munit/LinesSuite.scala
@@ -39,7 +39,7 @@ class LinesSuite extends FunSuite {
     test(options) {
       val obtained = munitLines
         .formatLine(location, message)
-        .replaceAllLiterally(location.path, location.filename)
+        .replace(location.path, location.filename)
       assertNoDiff(obtained, expected)
     }
   }


### PR DESCRIPTION
Fixes #183. Previously, Dotty reported a warning by default when using
functional fixtures because an implicit conversion was triggered. Now,
the warning is no longer reported since there is a method overload for
the common case where the argument is a string literal.

