### PR TITLE
Report accurate ScalaCheck seed on failing test

### DIFF
--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -49,13 +49,17 @@ trait ScalaCheckSuite extends FunSuite {
 
   private def propToTry(prop: Prop, test: Test): Try[Unit] = {
     import ScalaCheckTest._
-    def seed =
+    def makeSeed() =
       scalaCheckTestParameters.initialSeed.getOrElse(
         Seed.fromBase64(scalaCheckInitialSeed).get
       )
+    var seed: Seed = null
     val result = check(
       scalaCheckTestParameters,
-      Prop(genParams => prop(genParams.withInitialSeed(seed)))
+      Prop { genParams =>
+        seed = makeSeed()
+        prop(genParams.withInitialSeed(seed))
+      }
     )
     def renderResult(r: Result): String = {
       val resultMessage = Pretty.pretty(r, scalaCheckPrettyParameters)

--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -53,12 +53,14 @@ trait ScalaCheckSuite extends FunSuite {
       scalaCheckTestParameters.initialSeed.getOrElse(
         Seed.fromBase64(scalaCheckInitialSeed).get
       )
-    var seed: Seed = null
+    val initialSeed = makeSeed()
+    var seed: Seed = initialSeed
     val result = check(
       scalaCheckTestParameters,
       Prop { genParams =>
-        seed = makeSeed()
-        prop(genParams.withInitialSeed(seed))
+        val r = prop(genParams.withInitialSeed(seed))
+        seed = seed.next
+        r
       }
     )
     def renderResult(r: Result): String = {
@@ -66,10 +68,10 @@ trait ScalaCheckSuite extends FunSuite {
       if (r.passed) {
         resultMessage
       } else {
-        val seedMessage = s"""|Failing seed: ${seed.toBase64}
+        val seedMessage = s"""|Failing seed: ${initialSeed.toBase64}
                               |You can reproduce this failure by adding the following override to your suite:
                               |
-                              |  override val scalaCheckInitialSeed = "${seed.toBase64}"
+                              |  override val scalaCheckInitialSeed = "${initialSeed.toBase64}"
                               |""".stripMargin
         seedMessage + "\n" + resultMessage
       }

--- a/tests/shared/src/test/scala/munit/ScalaCheckInitialSeedSuite.scala
+++ b/tests/shared/src/test/scala/munit/ScalaCheckInitialSeedSuite.scala
@@ -3,9 +3,11 @@ package munit
 import scala.collection.mutable
 import org.scalacheck.Prop.forAll
 
-// Regression test for https://github.com/scalameta/munit/issues/118
-final class ScalaCheckSeedSuite extends ScalaCheckSuite {
+final class ScalaCheckInitialSeedSuite extends ScalaCheckSuite {
 
+  // initial seed should be used for the first out of 100 `minSuccessfulTests` only
+  override val scalaCheckInitialSeed =
+    "9SohH7wEYXCdXK4b9yM2d6TKIN2jBFcBs4QBta-2yTD="
   private val ints = mutable.Set.empty[Int]
 
   property("generating int") {

--- a/tests/shared/src/test/scala/munit/ScalaCheckSeedSuite.scala
+++ b/tests/shared/src/test/scala/munit/ScalaCheckSeedSuite.scala
@@ -16,6 +16,25 @@ final class ScalaCheckSeedSuite extends ScalaCheckSuite {
   }
 
   test("generated int are not all the same") {
+    println(ints)
+    assert(ints.size > 1)
+  }
+}
+
+final class ScalaCheckInitialSeedSuite extends ScalaCheckSuite {
+
+  // initial seed should be used for the first out of 100 `minSuccessfulTests` only
+  override val scalaCheckInitialSeed = "9SohH7wEYXCdXK4b9yM2d6TKIN2jBFcBs4QBta-2yTD="
+  private val ints = mutable.Set.empty[Int]
+
+  property("generating int") {
+    forAll { (i: Int) =>
+      ints.add(i)
+      true
+    }
+  }
+
+  test("generated int are not all the same") {
     assert(ints.size > 1)
   }
 }

--- a/tests/shared/src/test/scala/munit/ScalaCheckSeedSuite.scala
+++ b/tests/shared/src/test/scala/munit/ScalaCheckSeedSuite.scala
@@ -24,7 +24,8 @@ final class ScalaCheckSeedSuite extends ScalaCheckSuite {
 final class ScalaCheckInitialSeedSuite extends ScalaCheckSuite {
 
   // initial seed should be used for the first out of 100 `minSuccessfulTests` only
-  override val scalaCheckInitialSeed = "9SohH7wEYXCdXK4b9yM2d6TKIN2jBFcBs4QBta-2yTD="
+  override val scalaCheckInitialSeed =
+    "9SohH7wEYXCdXK4b9yM2d6TKIN2jBFcBs4QBta-2yTD="
   private val ints = mutable.Set.empty[Int]
 
   property("generating int") {


### PR DESCRIPTION
Failing seed reporting seems to be incorrect when `scalaCheckInitialSeed` is not overridden. In that case `def seed` would use `def scalaCheckInitialSeed: String = Seed.random().toBase64` and be different every time. Hence the 2 seeds seen here are actually not the ones causing test failure.

https://travis-ci.org/github/spotify/magnolify/jobs/708925430#L369

```
Failing seed: z9omj4mAsT7BcJQoh95CcofqurdkO_jIAGEWFPx7xZA=
You can reproduce this failure by adding the following override to your suite:
  override val scalaCheckInitialSeed = "5E72c0hWZ5ioOvDIj2udNT9KuVs1mGz8EBcV-3zyKgH="
```