### PR TITLE
Introduce a new "failComparison()" helper

### DIFF
--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckFailException.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckFailException.scala
@@ -2,6 +2,10 @@ package munit
 
 import scala.util.control.NoStackTrace
 
+@deprecated(
+  "This class is not used anywhere and will be removed in a future release",
+  "0.8.0"
+)
 class ScalaCheckFailException(message: String)
     extends Exception(message)
     with NoStackTrace

--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -85,7 +85,7 @@ trait ScalaCheckSuite extends FunSuite {
         Success(())
       case status @ PropException(_, e, _) =>
         e match {
-          case f: FailException =>
+          case f: FailExceptionLike[_] =>
             // Promote FailException (i.e failed assertions) to property failures
             val r = result.copy(status = Failed(status.args, status.labels))
             Failure(f.withMessage(e.getMessage() + "\n\n" + renderResult(r)))

--- a/munit/native/src/main/scala/org/junit/ComparisonFailure.scala
+++ b/munit/native/src/main/scala/org/junit/ComparisonFailure.scala
@@ -1,0 +1,11 @@
+package org.junit
+
+class ComparisonFailure(message: String, fExpected: String, fActual: String)
+    extends AssertionError(message) {
+
+  override def getMessage(): String = message
+
+  def getActual(): String = fActual
+
+  def getExpected(): String = fExpected
+}

--- a/munit/shared/src/main/scala/munit/ComparisonFailException.scala
+++ b/munit/shared/src/main/scala/munit/ComparisonFailException.scala
@@ -1,0 +1,32 @@
+package munit
+
+import org.junit.ComparisonFailure
+
+/**
+ * The base exception for all comparison failures.
+ *
+ * This class exists so that it can extend `org.junit.ComparisonFailure`,
+ * which is recognised by IntelliJ so that users can optionally compare the
+ * obtained/expected values in a GUI diff explorer.
+ *
+ * @param message the exception message.
+ * @param obtained the obtained value from this comparison.
+ * @param expected the expected value from this comparison.
+ * @param location the source location where this exception was thrown.
+ */
+class ComparisonFailException(
+    val message: String,
+    val obtained: Any,
+    val expected: Any,
+    val location: Location
+) extends ComparisonFailure(message, s"$expected", s"$obtained")
+    with FailExceptionLike[ComparisonFailException] {
+  override def getMessage: String = message
+  def withMessage(newMessage: String): ComparisonFailException =
+    new ComparisonFailException(
+      newMessage,
+      obtained,
+      expected,
+      location
+    )
+}

--- a/munit/shared/src/main/scala/munit/FailException.scala
+++ b/munit/shared/src/main/scala/munit/FailException.scala
@@ -6,6 +6,7 @@ class FailException(
     val isStackTracesEnabled: Boolean,
     val location: Location
 ) extends AssertionError(message, cause)
+    with FailExceptionLike[FailException]
     with Serializable {
   def this(message: String, location: Location) =
     this(message, null, true, location)

--- a/munit/shared/src/main/scala/munit/FailExceptionLike.scala
+++ b/munit/shared/src/main/scala/munit/FailExceptionLike.scala
@@ -1,0 +1,19 @@
+package munit
+
+/**
+ * The base class for all MUnit FailExceptions.
+ *
+ * Implementation note: this class exists so that we could fix the issue
+ * https://youtrack.jetbrains.com/issue/SCL-18255 In order to support the JUnit
+ * comparison GUI in IntelliJ we need to extend org.junit.ComparisonFailure,
+ * which is a class and not an interface. We can't make `munit.FailException`
+ * extend `org.junit.ComparisonFailure` since not all "fail exceptions" are
+ * "comparison failures". Instead, we introduced
+ * `munit.ComparisionFailException`, which extends
+ * `org.junit.ComparisonFailure` and this base trait. Internally, MUnit should
+ * match against `FailExceptionLike[_]` instead of `munit.FailException` directly.
+ */
+trait FailExceptionLike[T <: AssertionError] { self: AssertionError =>
+  def withMessage(message: String): T
+  def location: Location
+}

--- a/munit/shared/src/main/scala/munit/internal/console/Lines.scala
+++ b/munit/shared/src/main/scala/munit/internal/console/Lines.scala
@@ -15,6 +15,8 @@ class Lines extends Serializable {
   def formatLine(location: Location, message: String): String = {
     formatLine(location, message, new Clues(Nil))
   }
+  def formatPath(location: Location): String =
+    location.path
   def formatLine(location: Location, message: String, clues: Clues): String = {
     try {
       val path = Paths.get(location.path)
@@ -34,7 +36,7 @@ class Lines extends Serializable {
         }
         val isMultilineMessage = message.contains('\n')
         out
-          .append(location.path)
+          .append(formatPath(location))
           .append(':')
           .append(location.line.toString())
         if (message.length() > 0 && !isMultilineMessage) {

--- a/munit/shared/src/main/scala/munit/internal/difflib/ComparisonFailExceptionHandler.scala
+++ b/munit/shared/src/main/scala/munit/internal/difflib/ComparisonFailExceptionHandler.scala
@@ -1,0 +1,12 @@
+package munit.internal.difflib
+
+import munit.Location
+
+trait ComparisonFailExceptionHandler {
+  def handle(
+      message: String,
+      obtained: String,
+      expected: String,
+      location: Location
+  ): Nothing
+}

--- a/munit/shared/src/main/scala/munit/internal/difflib/Diffs.scala
+++ b/munit/shared/src/main/scala/munit/internal/difflib/Diffs.scala
@@ -7,6 +7,7 @@ object Diffs {
   def create(obtained: String, expected: String): Diff =
     new Diff(obtained, expected)
 
+  @deprecated("")
   def assertNoDiff(
       obtained: String,
       expected: String,
@@ -14,13 +15,41 @@ object Diffs {
       title: String = "",
       printObtainedAsStripMargin: Boolean = true
   )(implicit loc: Location): Boolean = {
+    assertNoDiff(
+      obtained,
+      expected,
+      new ComparisonFailExceptionHandler {
+        def handle(
+            message: String,
+            obtained: String,
+            expected: String,
+            loc: Location
+        ): Nothing = fail(message)
+      },
+      title,
+      printObtainedAsStripMargin
+    )
+  }
+
+  def assertNoDiff(
+      obtained: String,
+      expected: String,
+      handler: ComparisonFailExceptionHandler,
+      title: String,
+      printObtainedAsStripMargin: Boolean
+  )(implicit loc: Location): Boolean = {
     if (obtained.isEmpty && !expected.isEmpty) {
-      fail("Obtained empty output!")
+      handler.handle("Obtained empty output!", obtained, expected, loc)
     }
     val diff = new Diff(obtained, expected)
     if (diff.isEmpty) true
     else {
-      fail(diff.createReport(title, printObtainedAsStripMargin))
+      handler.handle(
+        diff.createReport(title, printObtainedAsStripMargin),
+        obtained,
+        expected,
+        loc
+      )
     }
   }
 

--- a/tests/shared/src/main/scala/munit/StackTraceFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/StackTraceFrameworkSuite.scala
@@ -27,10 +27,10 @@ class BaseStackTraceFrameworkSuite(arguments: Array[String], expected: String)
 object FullStackTraceFrameworkSuite
     extends BaseStackTraceFrameworkSuite(
       Array("-F"),
-      """|at munit.Assertions:fail
-         |  at munit.Assertions:fail$
-         |  at munit.FunSuite:fail
-         |  at munit.Assertions:$anonfun$assertNoDiff$2
+      """|at munit.Assertions:failComparison
+         |  at munit.Assertions:failComparison$
+         |  at munit.FunSuite:failComparison
+         |  at munit.Assertions$$anon$1:handle
          |==> failure munit.StackTraceFrameworkSuite.fail - /scala/munit/StackTraceFrameworkSuite.scala:5
          |4:  test("fail") {
          |5:    assertNoDiff("a", "b")

--- a/tests/shared/src/test/scala/munit/BaseSuite.scala
+++ b/tests/shared/src/test/scala/munit/BaseSuite.scala
@@ -1,8 +1,11 @@
 package munit
 
 import munit.internal.PlatformCompat
+import munit.internal.console.Lines
+import java.nio.file.Paths
 
 class BaseSuite extends FunSuite {
+
   override def munitTestTransforms: List[TestTransform] =
     super.munitTestTransforms ++ List(
       new TestTransform(

--- a/tests/shared/src/test/scala/munit/ComparisonFailExceptionSuite.scala
+++ b/tests/shared/src/test/scala/munit/ComparisonFailExceptionSuite.scala
@@ -1,0 +1,57 @@
+package munit
+
+import org.junit.ComparisonFailure
+import munit.internal.console.Lines
+import java.nio.file.Paths
+
+class ComparisonFailExceptionSuite extends BaseSuite {
+  override val munitLines: Lines = new Lines {
+    override def formatPath(location: Location): String = {
+      Paths.get(location.path).getFileName().toString()
+    }
+  }
+  test("comparison-failure") {
+    val e = intercept[ComparisonFailException] {
+      assertEquals[Any, Any](List("1", "2", "3"), List(1, 2))
+    }
+    assert(clue(e).isInstanceOf[ComparisonFailure])
+    // NOTE: assert that we use the `toString` of values in the
+    // `org.junit.ComparisionFailure` exception. The stdout message in the
+    // console still uses `munitPrint()`, which would have displayed `List("1",
+    // "2", "3")` instead of `List(1, 2, 3)`.
+    assertNoDiff(
+      e.getActual,
+      "List(1, 2, 3)"
+    )
+    assertNoDiff(
+      e.getExpected,
+      "List(1, 2)"
+    )
+    assertEquals(e.expected, List(1, 2))
+    assertEquals(e.obtained, List("1", "2", "3"))
+    assertNoDiff(
+      e.getMessage(),
+      """|ComparisonFailExceptionSuite.scala:15
+         |14:    val e = intercept[ComparisonFailException] {
+         |15:      assertEquals[Any, Any](List("1", "2", "3"), List(1, 2))
+         |16:    }
+         |values are not the same
+         |=> Obtained
+         |List(
+         |  "1",
+         |  "2",
+         |  "3"
+         |)
+         |=> Diff (- obtained, + expected)
+         | List(
+         |-  "1",
+         |-  "2",
+         |-  "3"
+         |+  1,
+         |+  2
+         | )
+         |""".stripMargin
+    )
+  }
+
+}

--- a/tests/shared/src/test/scala/munit/FailExceptionSuite.scala
+++ b/tests/shared/src/test/scala/munit/FailExceptionSuite.scala
@@ -2,6 +2,8 @@ package munit
 
 class FailExceptionSuite extends BaseSuite {
   test("assertion-error") {
-    val error: AssertionError = new FailException("", Location.generate)
+    intercept[AssertionError] {
+      fail("hello world!")
+    }
   }
 }


### PR DESCRIPTION
Previously, MUnit only supported failing tests with "fail(message)".
Now, users can optionally use the new `failComparison(message, obtained,
    expected)` method. This method throws a
`munit.ComparisonFailException`, which is recognised by IntelliJ's JUnit
runner making it possible to view the difference between the
obtained/expected values in a custom GUI diff window.

<img width="1352" alt="Screenshot 2020-10-18 at 09 51 45-fs8" src="https://user-images.githubusercontent.com/1408093/96361764-c9fb8480-1128-11eb-99ee-3f179fa8a46f.png">
