### PR TITLE
Switch to Scala 3 universal equality for `assertEquals()`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,28 +131,8 @@ lazy val junit = project
 lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     sharedSettings,
-    unmanagedSourceDirectories.in(Compile) ++= {
-      val root = baseDirectory.in(ThisBuild).value / "munit"
-      val base = root / "shared" / "src" / "main"
-      val result = mutable.ListBuffer.empty[File]
-      val partialVersion = CrossVersion.partialVersion(scalaVersion.value)
-      if (isScalaJS.value || isScalaNative.value) {
-        result += root / "non-jvm" / "src" / "main"
-      }
-      if (isPreScala213(partialVersion)) {
-        result += base / "scala-pre-2.13"
-      }
-      if (isNotScala211(partialVersion)) {
-        result += base / "scala-post-2.11"
-      }
-      if (isScala2(partialVersion)) {
-        result += base / "scala-2"
-      }
-      if (isScala3(partialVersion)) {
-        result += base / "scala-3"
-      }
-      result.toList
-    },
+    unmanagedSourceDirectories.in(Compile) ++=
+      crossBuildingDirectories("munit", "main").value,
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((0, _)) => Nil
@@ -244,6 +224,8 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         baseDirectory.in(ThisBuild).value / "tests" / "shared" / "src" / "main",
       scalaVersion
     ),
+    unmanagedSourceDirectories.in(Test) ++=
+      crossBuildingDirectories("tests", "test").value,
     skip in publish := true
   )
   .nativeConfigure(sharedNativeConfigure)
@@ -287,3 +269,27 @@ lazy val docs = project
     ),
     fork := false
   )
+
+def crossBuildingDirectories(name: String, config: String) =
+  Def.setting[Seq[File]] {
+    val root = baseDirectory.in(ThisBuild).value / name
+    val base = root / "shared" / "src" / config
+    val result = mutable.ListBuffer.empty[File]
+    val partialVersion = CrossVersion.partialVersion(scalaVersion.value)
+    if (isScalaJS.value || isScalaNative.value) {
+      result += root / "non-jvm" / "src" / config
+    }
+    if (isPreScala213(partialVersion)) {
+      result += base / "scala-pre-2.13"
+    }
+    if (isNotScala211(partialVersion)) {
+      result += base / "scala-post-2.11"
+    }
+    if (isScala2(partialVersion)) {
+      result += base / "scala-2"
+    }
+    if (isScala3(partialVersion)) {
+      result += base / "scala-3"
+    }
+    result.toList
+  }

--- a/munit/shared/src/main/scala-2/munit/internal/EqualityCompat.scala
+++ b/munit/shared/src/main/scala-2/munit/internal/EqualityCompat.scala
@@ -1,0 +1,13 @@
+package munit.internal
+
+trait EqualityCompat {
+
+  /**
+   * A Scala 2 "polyfill" for the upcoming multiversal equality in Scala 3
+   *
+   * http://dotty.epfl.ch/docs/reference/contextual/multiversal-equality.html
+   */
+  sealed abstract class Eql[A, B]
+  implicit def universalEqualityForScala2[A, B]: Eql[A, B] =
+    null.asInstanceOf[Eql[A, B]]
+}

--- a/munit/shared/src/main/scala-3/munit/internal/EqualityCompat.scala
+++ b/munit/shared/src/main/scala-3/munit/internal/EqualityCompat.scala
@@ -1,0 +1,4 @@
+package munit.internal
+
+trait EqualityCompat
+

--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -10,9 +10,10 @@ import scala.collection.mutable
 import munit.internal.console.AnsiColors
 import org.junit.AssumptionViolatedException
 import munit.internal.MacroCompat
+import munit.internal.EqualityCompat
 
 object Assertions extends Assertions
-trait Assertions extends MacroCompat.CompileErrorMacro {
+trait Assertions extends MacroCompat.CompileErrorMacro with EqualityCompat {
 
   val munitLines = new Lines
 
@@ -78,7 +79,7 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
       obtained: A,
       expected: B,
       clue: => Any = "values are the same"
-  )(implicit loc: Location, ev: A =:= B): Unit = {
+  )(implicit loc: Location, ev: Eql[A, B]): Unit = {
     StackTraces.dropInside {
       if (obtained == expected) {
         failComparison(
@@ -113,7 +114,7 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
       obtained: A,
       expected: B,
       clue: => Any = "values are not the same"
-  )(implicit loc: Location, ev: B <:< A): Unit = {
+  )(implicit loc: Location, ev: Eql[A, B]): Unit = {
     StackTraces.dropInside {
       if (obtained != expected) {
         Diffs.assertNoDiff(

--- a/tests/shared/src/test/scala-2/munit/AssertionsEqlSuite.scala
+++ b/tests/shared/src/test/scala-2/munit/AssertionsEqlSuite.scala
@@ -1,0 +1,7 @@
+package munit
+
+class AssertionsEqlSuite extends BaseSuite {
+  test("basic".fail) {
+    assertEquals(List("1"), List(1))
+  }
+}

--- a/tests/shared/src/test/scala-3/munit/AssertionsEqlSuite.scala
+++ b/tests/shared/src/test/scala-3/munit/AssertionsEqlSuite.scala
@@ -1,0 +1,51 @@
+package munit
+
+import scala.language.strictEquality
+
+class AssertionsEqlSuite extends BaseSuite {
+  test("nested-generic") {
+    assertNoDiff(
+      compileErrors("""assertNotEquals(List(1), List("1"))"""),
+    """|error:
+       |Values of types List[Int] and List[String] cannot be compared with == or !=.
+       |I found:
+       |
+       |    Eql.eqlSeq[Int, String](/* missing */summon[Eql[Int, String]])
+       |
+       |But no implicit values were found that match type Eql[Int, String].
+       |assertNotEquals(List(1), List("1"))
+       |                                  ^
+       |""".stripMargin
+    )
+  }
+
+  test("subtype") {
+    assertNoDiff(
+      compileErrors("""assertNotEquals(Some(1), Option(1))"""),
+      """|error: Values of types Some[Int] and Option[Int] cannot be compared with == or !=
+         |assertNotEquals(Some(1), Option(1))
+         |                                  ^
+         |""".stripMargin
+    )
+  }
+  test("supertype") {
+    assertNoDiff(
+      compileErrors("""assertNotEquals(Option(1), Some(1))"""),
+      """|error: Values of types Option[Int] and Some[Int] cannot be compared with == or !=
+         |assertNotEquals(Option(1), Some(1))
+         |                                  ^
+         |""".stripMargin
+    )
+  }
+  test("unrelated") {
+    class A
+    class B
+    assertNoDiff(
+      compileErrors("""assertNotEquals(new A, new B)"""),
+      """|error: Values of types A and B cannot be compared with == or !=
+         |assertNotEquals(new A, new B)
+         |                            ^
+         |""".stripMargin
+    )
+  }
+}

--- a/tests/shared/src/test/scala/munit/AssertionsSuite.scala
+++ b/tests/shared/src/test/scala/munit/AssertionsSuite.scala
@@ -50,12 +50,17 @@ class AssertionsSuite extends BaseSuite {
 
   test("subtype".tag(NoDotty)) {
     assertEquals(Option(1), Some(1))
-    assertNoDiff(
-      compileErrors("assertEquals(Some(1), Option(1))"),
-      """|error: Cannot prove that Option[Int] <:< Some[Int].
-         |assertEquals(Some(1), Option(1))
-         |            ^
-         |""".stripMargin
-    )
+    assertEquals(Some(1), Option(1))
+    class A {
+      override def equals(x: Any): Boolean = true
+    }
+    class B {
+      override def equals(x: Any): Boolean = true
+    }
+    // This compiles by default in Scala 3 because we haven't enabled strict
+    // equality for this file. See AssertionsEqlSuite for Scala 3 tests where
+    // strict equality is enabled and the following assertion fails to compile.
+    assertEquals(new A, new B)
   }
+
 }


### PR DESCRIPTION
Previously, MUnit had a subtyping constraint on `assertEquals(a, b)` so that it would fail to compile if `a` was not a subtype of `b`. This was a suboptimal solution because the compile error messages could become cryptic in some cases. Now, MUnit uses the new `Eql[A, B]` multiversal equality in Scala 3 (http://dotty.epfl.ch/docs/reference/contextual/multiversal-equality.html). For Scala 2, we drop the subtyping constraint so that it's no longer a compile error to compare unrelated types. If the values are different, then users will see a runtime error instead.



Fixes #189 