### PR TITLE
ScalaCheck 1.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalajs: ["1.0.1", "0.6.32"]
+        scalajs: ["1.3.0", "0.6.32"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,6 @@ inThisBuild(
     testFrameworks := List(
       new TestFramework("munit.Framework")
     ),
-    resolvers += Resolver.sonatypeRepo("public"),
     useSuperShell := false,
     scalacOptions ++= List(
       "-target:jvm-1.8",
@@ -216,8 +215,7 @@ lazy val munitScalacheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     moduleName := "munit-scalacheck",
     sharedSettings,
-    libraryDependencies += ("org.scalacheck" %%% "scalacheck" % "1.14.3")
-      .withDottyCompat(scalaVersion.value)
+    libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.15.0"
   )
   .jvmSettings(
     sharedJVMSettings,

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import sbtcrossproject.CrossPlugin.autoImport.CrossType
 import scala.collection.mutable
 val customScalaJSVersion = Option(System.getenv("SCALAJS_VERSION"))
-val scalaJSVersion = customScalaJSVersion.getOrElse("1.0.1")
+val scalaJSVersion = customScalaJSVersion.getOrElse("1.3.0")
 val scalaNativeVersion = "0.4.0-M2"
 def scala213 = "2.13.2"
 def scala212 = "2.12.11"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.1")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.3.0")
 
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")


### PR DESCRIPTION
Scalacheck is natively built for Dotty.

Since 1.15.0 (and other releases in the 1.15.x series) are binary compatible to 1.14.0, the transition should be smooth.

~1.15.0 final should follow after RC1 next week. I've opened this PR with the RC to figure out if there are any remaining issues with it.~