### PR TITLE
Upgrade to Scalacheck 1.15.0 and use Dotty build of it

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -216,8 +216,7 @@ lazy val munitScalacheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     moduleName := "munit-scalacheck",
     sharedSettings,
-    libraryDependencies += ("org.scalacheck" %%% "scalacheck" % "1.14.3")
-      .withDottyCompat(scalaVersion.value)
+    libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.15.0"
   )
   .jvmSettings(
     sharedJVMSettings,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.1")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.3.0")
 
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")


### PR DESCRIPTION
Unlike #235, this PR adjusts the scalacheck dependency to use the Dotty version