### PR TITLE
Enable mima

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,24 @@ jobs:
             ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_APPLICATION_CREDENTIALS_JSON:
             ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
-  checks:
+  mima:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v7
+      - run: sbt mimaReportBinaryIssues
+  scalafmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v7
       - run: ./bin/scalafmt --check
+  docs:
+    name: Scalafix and Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v7
       - run: sbt scalafixAll
       - run: sbt docs/docusaurusCreateSite
         env:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0-M2")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 
 libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "1.113.2"
 


### PR DESCRIPTION
Previously, binary compatibility was maintained on a best-effort basis.
With growing number of external libraries that integrate with MUnit,
it's critical that we take binary breaking changes seriously. This
commit enables Mima so that the CI fails when we introduce binary
breaking changes. The binary breaking changes that have happened since
v0.7.0 are mostly irrelevant for most users (internal APIs that were
accidentally public)