### PR TITLE
Update Scala 3 version to 3.0.0-M1

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -9,7 +9,7 @@ coursier resolve \
   org.scalameta:munit_2.11:$version \
   org.scalameta:munit_2.12:$version \
   org.scalameta:munit_2.13:$version \
-  org.scalameta:munit_0.26:$version \
+  org.scalameta:munit_3.0:$version \
   org.scalameta:munit_0.27:$version \
   org.scalameta:munit_native0.4.0-M2_2.11:$version \
   org.scalameta:munit_sjs0.6_2.11:$version \
@@ -21,8 +21,8 @@ coursier resolve \
   org.scalameta:munit-scalacheck_2.11:$version \
   org.scalameta:munit-scalacheck_2.12:$version \
   org.scalameta:munit-scalacheck_2.13:$version \
-  org.scalameta:munit-scalacheck_0.26:$version \
   org.scalameta:munit-scalacheck_0.27:$version \
+  org.scalameta:munit-scalacheck_3.0:$version \
   org.scalameta:munit-scalacheck_native0.4.0-M2_2.11:$version \
   org.scalameta:munit-scalacheck_sjs0.6_2.11:$version \
   org.scalameta:munit-scalacheck_sjs0.6_2.12:$version \

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ def previousVersion = "0.7.0"
 def scala213 = "2.13.2"
 def scala212 = "2.12.11"
 def scala211 = "2.11.12"
-def dottyNext = "0.27.0-RC1"
-def dottyStable = "0.26.0"
+def scala3Stable = "3.0.0-M1"
+def scala3Previous = "0.27.0-RC1"
 def junitVersion = "4.13"
 def gcp = "com.google.cloud" % "google-cloud-storage" % "1.113.2"
 inThisBuild(
@@ -62,11 +62,11 @@ addCommandAlias(
 )
 val isPreScala213 = Set[Option[(Long, Long)]](Some((2, 11)), Some((2, 12)))
 val scala2Versions = List(scala213, scala212, scala211)
-val scala3Versions = List(dottyNext, dottyStable)
+val scala3Versions = List(scala3Previous, scala3Stable)
 val allScalaVersions = scala2Versions ++ scala3Versions
 def isNotScala211(v: Option[(Long, Long)]): Boolean = !v.contains((2, 11))
 def isScala2(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2)
-def isScala3(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 0)
+def isScala3(v: Option[(Long, Long)]): Boolean = v.exists(_._1 != 2)
 val isScalaJS = Def.setting[Boolean](
   SettingKey[Boolean]("scalaJSUseMainModuleInitializer").?.value.isDefined
 )
@@ -132,7 +132,7 @@ val sharedSettings = List(
           "-Xexperimental",
           "-Ywarn-unused-import"
         )
-      case Some((0, _)) => List()
+      case Some((major, _)) if major != 2 => List()
       case _ =>
         List(
           "-target:jvm-1.8",
@@ -191,7 +191,7 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     },
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((0, _)) => Nil
+        case Some((major, _)) if major != 2 => Nil
         case _ =>
           List(
             "org.scala-lang" % "scala-reflect" % scalaVersion.value
@@ -321,9 +321,8 @@ lazy val docs = project
     mdocExtraArguments := List("--no-link-hygiene"),
     mdocVariables := Map(
       "VERSION" -> version.value.replaceFirst("\\+.*", ""),
-      "DOTTY_VERSION" -> dottyNext,
-      "DOTTY_NEXT_VERSION" -> dottyNext,
-      "DOTTY_STABLE_VERSION" -> dottyStable,
+      "SCALA3_PREVIOUS_VERSION" -> scala3Stable,
+      "SCALA3_STABLE_VERSION" -> scala3Stable,
       "SUPPORTED_SCALA_VERSIONS" -> allScalaVersions.mkString(", ")
     ),
     fork := false

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,13 +27,13 @@ libraryDependencies += "org.scalameta" %% "munit" % "@VERSION@" % Test
 testFrameworks += new TestFramework("munit.Framework")
 ```
 
-| Scala Version          | JVM | Scala.js (0.6.x, 1.x) | Native (0.4.x) |
-| ---------------------- | :-: | :-------------------: | :------------: |
-| 2.11.x                 | ✅  |          ✅           |       ✅       |
-| 2.12.x                 | ✅  |          ✅           |      n/a       |
-| 2.13.x                 | ✅  |          ✅           |      n/a       |
-| @DOTTY_NEXT_VERSION@   | ✅  |          n/a          |      n/a       |
-| @DOTTY_STABLE_VERSION@ | ✅  |          n/a          |      n/a       |
+| Scala Version             | JVM | Scala.js (0.6.x, 1.x) | Native (0.4.x) |
+| ------------------------- | :-: | :-------------------: | :------------: |
+| 2.11.x                    | ✅  |          ✅           |       ✅       |
+| 2.12.x                    | ✅  |          ✅           |      n/a       |
+| 2.13.x                    | ✅  |          ✅           |      n/a       |
+| @SCALA3_PREVIOUS_VERSION@ | ✅  |          n/a          |      n/a       |
+| @SCALA3_STABLE_VERSION@   | ✅  |          n/a          |      n/a       |
 
 Next, write a test suite.
 

--- a/tests/shared/src/test/scala/munit/BaseSuite.scala
+++ b/tests/shared/src/test/scala/munit/BaseSuite.scala
@@ -12,7 +12,7 @@ class BaseSuite extends FunSuite {
         "BaseSuite",
         { test =>
           def isDotty: Boolean =
-            BuildInfo.scalaVersion.startsWith("0.")
+            !BuildInfo.scalaVersion.startsWith("2.")
           def is213: Boolean =
             BuildInfo.scalaVersion.startsWith("2.13") || isDotty
           if (test.tags(NoDotty) && isDotty) {


### PR DESCRIPTION
Connected to https://github.com/scalameta/munit/issues/240

Seems we are no longer getting RC versions, so I reverted back to having single stable Dotty version.