### PR TITLE
enable DottyJS, drop Scala.js 0.6.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,12 @@ jobs:
   js:
     strategy:
       fail-fast: false
-      matrix:
-        scalajs: ["1.3.0", "0.6.32"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v7
       - run: sbt +testsJS/test
         env:
-          SCALAJS_VERSION: ${{ matrix.scalajs }}
           GOOGLE_APPLICATION_CREDENTIALS:
             ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_APPLICATION_CREDENTIALS_JSON:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Publish ${{ github.ref }}
         run: |
           sbt ci-release
-          SCALAJS_VERSION=0.6.32 sbt clean sonatypeBundleClean ci-release
           sbt docs/docusaurusPublishGhpages
         env:
           GIT_USER: munit@scalameta.org

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,7 @@ import com.typesafe.tools.mima.core.MissingTypesProblem
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import sbtcrossproject.CrossPlugin.autoImport.CrossType
 import scala.collection.mutable
-val customScalaJSVersion = Option(System.getenv("SCALAJS_VERSION"))
-val scalaJSVersion = customScalaJSVersion.getOrElse("1.3.0")
+val scalaJSVersion = "1.3.0"
 val scalaNativeVersion = "0.4.0-M2"
 def previousVersion = "0.7.0"
 def scala213 = "2.13.2"
@@ -151,7 +150,6 @@ lazy val junit = project
     mimaEnable,
     moduleName := "junit-interface",
     description := "A Java implementation of sbt's test interface for JUnit 4",
-    skip in publish := customScalaJSVersion.isDefined,
     autoScalaLibrary := false,
     crossPaths := false,
     sbtPlugin := false,
@@ -202,7 +200,6 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .nativeConfigure(sharedNativeConfigure)
   .nativeSettings(
     sharedNativeSettings,
-    skip in publish := customScalaJSVersion.isDefined,
     libraryDependencies ++= List(
       "org.scala-native" %%% "test-interface" % scalaNativeVersion
     )
@@ -217,7 +214,6 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .jvmSettings(
     sharedJVMSettings,
-    skip in publish := customScalaJSVersion.isDefined,
     libraryDependencies ++= List(
       "junit" % "junit" % "4.13.1"
     )
@@ -234,7 +230,6 @@ lazy val plugin = project
     sharedSettings,
     moduleName := "sbt-munit",
     sbtPlugin := true,
-    skip in publish := customScalaJSVersion.isDefined,
     scalaVersion := scala212,
     crossScalaVersions := List(scala212),
     buildInfoPackage := "munit.sbtmunit",
@@ -257,13 +252,11 @@ lazy val munitScalacheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.15.0"
   )
   .jvmSettings(
-    sharedJVMSettings,
-    skip in publish := customScalaJSVersion.isDefined
+    sharedJVMSettings
   )
   .nativeConfigure(sharedNativeConfigure)
   .nativeSettings(
-    sharedNativeSettings,
-    skip in publish := customScalaJSVersion.isDefined
+    sharedNativeSettings
   )
   .jsConfigure(sharedJSConfigure)
   .jsSettings(sharedJSSettings)
@@ -305,7 +298,6 @@ lazy val docs = project
   .settings(
     sharedSettings,
     moduleName := "munit-docs",
-    skip in publish := customScalaJSVersion.isDefined,
     crossScalaVersions := List(scala213, scala212),
     unmanagedSources.in(Compile) += sourceDirectory
       .in(plugin, Compile)

--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,7 @@ val sharedJVMSettings: List[Def.Setting[_]] = List(
 ) ++ mimaEnable
 val sharedJSSettings: List[Def.Setting[_]] = List(
   skipIdeaSettings,
-  crossScalaVersions := scala2Versions,
+  crossScalaVersions := allScalaVersions.filterNot(_.startsWith("0.")),
   scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
 )
 val sharedJSConfigure: Project => Project =
@@ -208,8 +208,10 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .jsSettings(
     sharedJSSettings,
     libraryDependencies ++= List(
-      "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion,
-      "org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion
+      ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion)
+        .withDottyCompat(scalaVersion.value),
+      ("org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion)
+        .withDottyCompat(scalaVersion.value)
     )
   )
   .jvmSettings(
@@ -249,7 +251,7 @@ lazy val munitScalacheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     moduleName := "munit-scalacheck",
     sharedSettings,
-    libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.15.0"
+    libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.15.1"
   )
   .jvmSettings(
     sharedJVMSettings

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,13 +27,13 @@ libraryDependencies += "org.scalameta" %% "munit" % "@VERSION@" % Test
 testFrameworks += new TestFramework("munit.Framework")
 ```
 
-| Scala Version             | JVM | Scala.js (0.6.x, 1.x) | Native (0.4.x) |
-| ------------------------- | :-: | :-------------------: | :------------: |
-| 2.11.x                    | ✅  |          ✅           |       ✅       |
-| 2.12.x                    | ✅  |          ✅           |      n/a       |
-| 2.13.x                    | ✅  |          ✅           |      n/a       |
-| @SCALA3_PREVIOUS_VERSION@ | ✅  |          n/a          |      n/a       |
-| @SCALA3_STABLE_VERSION@   | ✅  |          n/a          |      n/a       |
+| Scala Version             | JVM | Scala.js (0.6.x) |  Scala.js (1.x) | Native (0.4.x) |
+| ------------------------- | :-: | :--------------: |  :------------: | :------------: |
+| 2.11.x                    | ✅  | ✅ until 0.7.16  |        ✅       |       ✅       |
+| 2.12.x                    | ✅  | ✅ until 0.7.16  |        ✅       |      n/a       |
+| 2.13.x                    | ✅  | ✅ until 0.7.16  |        ✅       |      n/a       |
+| @SCALA3_PREVIOUS_VERSION@ | ✅  |        n/a       |        ✅       |      n/a       |
+| @SCALA3_STABLE_VERSION@   | ✅  |        n/a       |        ✅       |      n/a       |
 
 Next, write a test suite.
 

--- a/munit/js/src/main/scala/munit/internal/JSIO.scala
+++ b/munit/js/src/main/scala/munit/internal/JSIO.scala
@@ -90,7 +90,8 @@ object JSPath extends js.Any {
 object JSIO {
   private[internal] val process: JSProcess =
     js.Dynamic.global.process.asInstanceOf[JSProcess]
-  def isNode: Boolean = !js.isUndefined(process) && !js.isUndefined(process.cwd)
+  def isNode: Boolean =
+    !js.isUndefined(process) && !js.isUndefined(process.cwd())
 
   def inNode[T](f: => T): T =
     if (JSIO.isNode) f

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/IncludeFilter.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/IncludeFilter.scala
@@ -14,8 +14,8 @@ class TagsFilter(
       var isExcluded = false
       description.getAnnotations.foreach {
         case t: Tag =>
-          isIncluded ||= include.contains(t.value())
-          isExcluded ||= exclude.contains(t.value())
+          isIncluded ||= include.contains(t.value)
+          isExcluded ||= exclude.contains(t.value)
         case _ =>
       }
       isIncluded && !isExcluded

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitFramework.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitFramework.scala
@@ -53,7 +53,7 @@ abstract class JUnitFramework extends Framework {
     var logAssert = false
     var notLogExceptionClass = false
     var useSbtLoggers = false
-    var trimStackTraces = defaults.trimStackTraces()
+    var trimStackTraces = defaults.trimStackTraces
     var includeTags = Set.empty[String]
     var excludeTags = Set.empty[String]
     for (str <- args) {

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/Settings.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/Settings.scala
@@ -1,11 +1,11 @@
 package munit.internal.junitinterface
 
 trait Settings {
-  def trimStackTraces(): Boolean
+  def trimStackTraces: Boolean
 }
 
 object Settings {
   def defaults(): Settings = new Settings {
-    def trimStackTraces(): Boolean = true
+    def trimStackTraces: Boolean = true
   }
 }

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/Tag.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/Tag.scala
@@ -1,5 +1,5 @@
 package munit.internal.junitinterface
 
 trait Tag {
-  def value(): String
+  def value: String
 }

--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -82,7 +82,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
     )
   }
 
-  override def getDescription: Description = {
+  override def getDescription(): Description = {
     val description = Description.createSuiteDescription(cls)
 
     try {
@@ -104,7 +104,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
     Await.result(runAsync(notifier), Duration.Inf)
   }
   def runAsync(notifier: RunNotifier): Future[Unit] = {
-    val description = getDescription
+    val description = getDescription()
     notifier.fireTestSuiteStarted(description)
     try {
       runAll(notifier)
@@ -139,7 +139,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
 
   private def runAll(notifier: RunNotifier): Future[Unit] = {
     if (PlatformCompat.isIgnoreSuite(cls)) {
-      val description = getDescription
+      val description = getDescription()
       notifier.fireTestIgnored(description)
       return Future.successful(())
     }
@@ -356,7 +356,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
     notifier.fireTestFinished(description)
   }
   private def trimStackTrace(ex: Throwable): Unit = {
-    if (settings.trimStackTraces()) {
+    if (settings.trimStackTraces) {
       StackTraces.trimStackTrace(ex)
     }
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,3 @@
-val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.3.0")
-
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.11")
@@ -10,7 +7,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.23")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0-M2")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 
 libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "1.113.2"


### PR DESCRIPTION
Drop Scala.js 0.6.x and enable DottyJS for 3.0.0-M1.

I haven't enabled DottyJS for 0.27 because tests are somehow failing there.

Should help fix #199. Obsoletes #246.