### PR TITLE
Check with Scalafix in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10
-      - run: sbt scalafixAll
+      - run: sbt scalafixCheckAll
       - run: sbt docs/docusaurusCreateSite
         env:
           GOOGLE_APPLICATION_CREDENTIALS:

--- a/tests/shared/src/test/scala/munit/BaseSuite.scala
+++ b/tests/shared/src/test/scala/munit/BaseSuite.scala
@@ -1,8 +1,6 @@
 package munit
 
 import munit.internal.PlatformCompat
-import munit.internal.console.Lines
-import java.nio.file.Paths
 
 class BaseSuite extends FunSuite {
 

--- a/tests/shared/src/test/scala/munit/LinesSuite.scala
+++ b/tests/shared/src/test/scala/munit/LinesSuite.scala
@@ -44,8 +44,8 @@ class LinesSuite extends FunSuite {
     }
   }
 
-  val line = Location.generate.line + 7
-  val endOfFileExpected =
+  val line: Int = Location.generate.line + 7
+  val endOfFileExpected: String =
     s"""|LinesSuite.scala:${line} issue-211
         |${line - 1}:  // hello!
         |${line}:  check("end-of-file", "issue-211", Location.generate, endOfFileExpected ) }


### PR DESCRIPTION
Previously, the CI ran Scalafix but without the --check flag so it
didn't fail the build if there were unused imports.