### PR TITLE
Fix bug related to escaping single quotes inside strings.

### DIFF
--- a/munit/shared/src/main/scala/munit/internal/console/Printers.scala
+++ b/munit/shared/src/main/scala/munit/internal/console/Printers.scala
@@ -34,7 +34,8 @@ object Printers {
           case x: Printable => x.print(out, indent)
           case x: Char =>
             out.append('\'')
-            printChar(x, out)
+            if (x == '\'') out.append("\\'")
+            else printChar(x, out)
             out.append('\'')
           case x: Byte   => out.append(x.toString())
           case x: Short  => out.append(x.toString())
@@ -190,7 +191,6 @@ object Printers {
   private def printChar(c: Char, sb: StringBuilder) =
     (c: @switch) match {
       case '"'  => sb.append("\\\"")
-      case '\'' => sb.append("\\'")
       case '\\' => sb.append("\\\\")
       case '\b' => sb.append("\\b")
       case '\f' => sb.append("\\f")

--- a/tests/shared/src/test/scala/munit/PrintersSuite.scala
+++ b/tests/shared/src/test/scala/munit/PrintersSuite.scala
@@ -39,6 +39,16 @@ class PrintersSuite extends FunSuite { self =>
     "'\\n'"
   )
   check(
+    "char-single-quote",
+    '\'',
+    "'\\''"
+  )
+  check(
+    "string-single-quote",
+    "'a'",
+    "\"'a'\""
+  )
+  check(
     "map",
     Map(1 -> 2, 3 -> 4, 5 -> Map(6 -> 7)),
     """|Map(


### PR DESCRIPTION
Previously, MUnit escaped single quotes inside strings. The escaping is
only needed for single-quote characters.