### PR TITLE
Fix #258 - escape "non-visible" characters in test names.

### DIFF
--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -24,6 +24,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 import java.util.concurrent.ExecutionException
 import munit.internal.junitinterface.Settings
+import munit.internal.console.Printers
 
 class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
     extends Runner
@@ -62,7 +63,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
   def createTestDescription(test: suite.Test): Description = {
     descriptions.getOrElseUpdate(
       test, {
-        val escapedName = test.name.replace("\n", "\\n")
+        val escapedName = Printers.escapeNonVisible(test.name)
         val testName = munit.internal.Compat.LazyList
           .from(0)
           .map {

--- a/tests/shared/src/main/scala/munit/TestNameFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/TestNameFrameworkSuite.scala
@@ -1,22 +1,30 @@
 package munit
 
 class TestNameFrameworkSuite extends FunSuite {
-  test("basic") {
-    // pass
-  }
-  test("basic") {
-    // pass
-  }
-  test("newline\n") {
-    // pass
-  }
+  test("basic") {}
+  test("basic") {}
+  test("newline\n") {}
+  test("carriage-return\r\n") {}
+  test("tab\t") {}
+  test("return\t") {}
+  test("form-feed\f") {}
+  test("substitute\u001az") {}
+  test("emoji😆") {}
+  test("red" + Console.RED) {}
 }
 
 object TestNameFrameworkSuite
     extends FrameworkTest(
       classOf[TestNameFrameworkSuite],
-      """|==> success munit.TestNameFrameworkSuite.basic
-         |==> success munit.TestNameFrameworkSuite.basic-1
-         |==> success munit.TestNameFrameworkSuite.newline\n
-         |""".stripMargin
+      s"""|==> success munit.TestNameFrameworkSuite.basic
+          |==> success munit.TestNameFrameworkSuite.basic-1
+          |==> success munit.TestNameFrameworkSuite.newline\\n
+          |==> success munit.TestNameFrameworkSuite.carriage-return\\r\\n
+          |==> success munit.TestNameFrameworkSuite.tab\\t
+          |==> success munit.TestNameFrameworkSuite.return\\t
+          |==> success munit.TestNameFrameworkSuite.form-feed\\f
+          |==> success munit.TestNameFrameworkSuite.substitute\\u001az
+          |==> success munit.TestNameFrameworkSuite.emoji😆
+          |==> success munit.TestNameFrameworkSuite.red\\u001b[31m
+          |""".stripMargin
     )


### PR DESCRIPTION
Previously, test reports didn't properly escape characters like
carriage returns \r in test names. This commit fixes this bug
for \r along with several other categories of characters that
benefit from escaping.