### PR TITLE
Mix Scala 2 macros in MUnit Scala 3 module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,10 @@ val sharedSettings = List(
           "-Xexperimental",
           "-Ywarn-unused-import"
         )
-      case Some((major, _)) if major != 2 => List()
+      case Some((major, _)) if major != 2 =>
+        List(
+          "-language:implicitConversions"
+        )
       case _ =>
         List(
           "-target:jvm-1.8",

--- a/build.sbt
+++ b/build.sbt
@@ -40,11 +40,7 @@ inThisBuild(
     testFrameworks := List(
       new TestFramework("munit.Framework")
     ),
-    useSuperShell := false,
-    scalacOptions ++= List(
-      "-target:jvm-1.8",
-      "-language:implicitConversions"
-    )
+    useSuperShell := false
   )
 )
 
@@ -187,15 +183,12 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       }
       result.toList
     },
-    libraryDependencies ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((major, _)) if major != 2 => Nil
-        case _ =>
-          List(
-            "org.scala-lang" % "scala-reflect" % scalaVersion.value
-          )
-      }
-    }
+    libraryDependencies ++= List(
+      "org.scala-lang" % "scala-reflect" % {
+        if (isDotty.value) scala213
+        else scalaVersion.value
+      } % Provided
+    )
   )
   .nativeConfigure(sharedNativeConfigure)
   .nativeSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,8 @@ val sharedSettings = List(
         List(
           "-Yrangepos",
           "-Xexperimental",
-          "-Ywarn-unused-import"
+          "-Ywarn-unused-import",
+          "-target:jvm-1.8"
         )
       case Some((major, _)) if major != 2 =>
         List(

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,10 @@ val scala3Versions = scala3Stable :: scala3Previous
 val allScalaVersions = scala2Versions ++ scala3Versions
 def isNotScala211(v: Option[(Long, Long)]): Boolean = !v.contains((2, 11))
 def isScala2(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2)
+val isScala3Setting = Def.setting {
+  isScala3(CrossVersion.partialVersion(scalaVersion.value))
+}
+
 def isScala3(v: Option[(Long, Long)]): Boolean = v.exists(_._1 != 2)
 val isScalaJS = Def.setting[Boolean](
   SettingKey[Boolean]("scalaJSUseMainModuleInitializer").?.value.isDefined
@@ -189,7 +193,7 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     },
     libraryDependencies ++= List(
       "org.scala-lang" % "scala-reflect" % {
-        if (isDotty.value) scala213
+        if (isScala3Setting.value) scala213
         else scalaVersion.value
       } % Provided
     )

--- a/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
@@ -3,103 +3,19 @@ package munit.internal
 import munit.Clue
 import munit.Location
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox.Context
-import scala.reflect.macros.TypecheckException
-import scala.reflect.macros.ParseException
 
 object MacroCompat {
 
   trait LocationMacro {
-    implicit def generate: Location = macro locationImpl
-  }
-
-  def locationImpl(c: Context): c.Tree = {
-    import c.universe._
-    val line = Literal(Constant(c.enclosingPosition.line))
-    val path = Literal(Constant(c.enclosingPosition.source.path))
-    New(typeOf[Location], path, line)
+    implicit def generate: Location = macro MacroCompatScala2.locationImpl
   }
 
   trait ClueMacro {
-    implicit def generate[T](value: T): Clue[T] = macro clueImpl
-  }
-
-  def clueImpl(c: Context)(value: c.Tree): c.Tree = {
-    import c.universe._
-    import compat._
-    val text: String =
-      if (value.pos != null && value.pos.isRange) {
-        val chars = value.pos.source.content
-        val start = value.pos.start
-        val end = value.pos.end
-        if (
-          end > start &&
-          start >= 0 && start < chars.length &&
-          end >= 0 && end < chars.length
-        ) {
-          new String(chars, start, end - start)
-        } else {
-          ""
-        }
-      } else {
-        ""
-      }
-    def simplifyType(tpe: Type): Type = tpe match {
-      case TypeRef(ThisType(pre), sym, args) if pre == sym.owner =>
-        simplifyType(TypeRef(NoPrefix, sym, args))
-      case t =>
-        // uncomment to debug:
-        // Printers.log(t)(Location.empty)
-        t.widen
-    }
-    val source = Literal(Constant(text))
-    val valueType = Literal(Constant(simplifyType(value.tpe).toString()))
-    New(
-      TypeRef(NoPrefix, typeOf[Clue[_]].typeSymbol, List(value.tpe.widen)),
-      source,
-      value,
-      valueType
-    )
+    implicit def generate[T](value: T): Clue[T] = macro MacroCompatScala2.clueImpl
   }
 
   trait CompileErrorMacro {
-    def compileErrors(code: String): String = macro compileErrorsImpl
+    def compileErrors(code: String): String = macro MacroCompatScala2.compileErrorsImpl
   }
 
-  def compileErrorsImpl(c: Context)(code: c.Tree): c.Tree = {
-    import c.universe._
-    val toParse: String = code match {
-      case Literal(Constant(literal: String)) => literal
-      case _ =>
-        c.abort(
-          code.pos,
-          "cannot compile dynamic expressions, only constant literals.\n" +
-            "To fix this problem, pass in a string literal in double quotes \"...\""
-        )
-    }
-
-    def formatError(message: String, pos: scala.reflect.api.Position): String =
-      new StringBuilder()
-        .append("error:")
-        .append(if (message.contains('\n')) "\n" else " ")
-        .append(message)
-        .append("\n")
-        .append(pos.lineContent)
-        .append("\n")
-        .append(" " * (pos.column - 1))
-        .append("^")
-        .toString()
-
-    val message: String =
-      try {
-        c.typecheck(c.parse(s"{\n$toParse\n}"))
-        ""
-      } catch {
-        case e: ParseException =>
-          formatError(e.getMessage(), e.pos)
-        case e: TypecheckException =>
-          formatError(e.getMessage(), e.pos)
-      }
-    Literal(Constant(message))
-  }
 }

--- a/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
@@ -3,6 +3,7 @@ package munit.internal
 import munit.Clue
 import munit.Location
 import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
 
 object MacroCompat {
 
@@ -10,12 +11,21 @@ object MacroCompat {
     implicit def generate: Location = macro MacroCompatScala2.locationImpl
   }
 
+  @deprecated("Use MacroCompatScala2.locationImpl instead", "2020-01-06")
+  def locationImpl(c: Context): c.Tree = MacroCompatScala2.locationImpl(c)
+
   trait ClueMacro {
     implicit def generate[T](value: T): Clue[T] = macro MacroCompatScala2.clueImpl
   }
 
+  @deprecated("Use MacroCompatScala2.clueImpl instead", "2020-01-06")
+  def clueImpl(c: Context)(value: c.Tree): c.Tree = MacroCompatScala2.clueImpl(c)(value)
+
   trait CompileErrorMacro {
     def compileErrors(code: String): String = macro MacroCompatScala2.compileErrorsImpl
   }
+
+  @deprecated("Use MacroCompatScala2.compileErrorsImpl instead", "2020-01-06")
+  def compileErrorsImpl(c: Context)(value: c.Tree): c.Tree = MacroCompatScala2.compileErrorsImpl(c)(value)
 
 }

--- a/munit/shared/src/main/scala-3.0.0-M2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3.0.0-M2/munit/internal/MacroCompat.scala
@@ -4,9 +4,6 @@ import munit.Clue
 import munit.Location
 import scala.quoted._
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox.Context
-import scala.reflect.macros.TypecheckException
-import scala.reflect.macros.ParseException
 
 object MacroCompat {
 

--- a/munit/shared/src/main/scala-3.0.0-M2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3.0.0-M2/munit/internal/MacroCompat.scala
@@ -3,11 +3,23 @@ package munit.internal
 import munit.Clue
 import munit.Location
 import scala.quoted._
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+import scala.reflect.macros.TypecheckException
+import scala.reflect.macros.ParseException
 
 object MacroCompat {
 
   trait LocationMacro {
     inline implicit def generate: Location = ${ locationImpl() }
+    implicit def generate: Location = macro locationImplScala2
+  }
+
+  def locationImplScala2(c: Context): c.Tree = {
+    import c.universe._
+    val line = Literal(Constant(c.enclosingPosition.line))
+    val path = Literal(Constant(c.enclosingPosition.source.path))
+    New(c.mirror.staticClass(classOf[Location].getName()), path, line)
   }
 
   def locationImpl()(using Quotes): Expr[Location] = {
@@ -20,6 +32,7 @@ object MacroCompat {
 
   trait ClueMacro {
     inline implicit def generate[T](value: T): Clue[T] = ${ clueImpl('value) }
+    implicit def generate[T](value: T): Clue[T] = macro clueImplScala2
   }
 
   def clueImpl[T: Type](value: Expr[T])(using Quotes): Expr[Clue[T]] = {
@@ -27,6 +40,44 @@ object MacroCompat {
     val source = Term.of(value).pos.sourceCode
     val valueType = Type.show[T]
     '{ new Clue(${Expr(source)}, $value, ${Expr(valueType)}) }
+  }
+
+  def clueImplScala2(c: Context)(value: c.Tree): c.Tree = {
+    import c.universe._
+    import compat._
+    val text: String =
+      if (value.pos != null && value.pos.isRange) {
+        val chars = value.pos.source.content
+        val start = value.pos.start
+        val end = value.pos.end
+        if (
+          end > start &&
+          start >= 0 && start < chars.length &&
+          end >= 0 && end < chars.length
+        ) {
+          new String(chars, start, end - start)
+        } else {
+          ""
+        }
+      } else {
+        ""
+      }
+    def simplifyType(tpe: Type): Type = tpe match {
+      case TypeRef(ThisType(pre), sym, args) if pre == sym.owner =>
+        simplifyType(TypeRef(NoPrefix, sym, args))
+      case t =>
+        // uncomment to debug:
+        // Printers.log(t)(Location.empty)
+        t.widen
+    }
+    val source = Literal(Constant(text))
+    val valueType = Literal(Constant(simplifyType(value.tpe).toString()))
+    New(
+      TypeRef(NoPrefix, c.mirror.staticClass(classOf[Clue[_]].getName), List(value.tpe.widen)),
+      source,
+      value,
+      valueType
+    )
   }
 
   trait CompileErrorMacro {
@@ -42,6 +93,44 @@ object MacroCompat {
         s"error:${separator}${trimMessage}\n${error.lineContent}\n${indent}^"
       }.mkString("\n")
     }
+    def compileErrors(code: String): String = macro compileErrorsImplScala2
+  }
+
+  def compileErrorsImplScala2(c: Context)(code: c.Tree): c.Tree = {
+    import c.universe._
+    val toParse: String = code match {
+      case Literal(Constant(literal: String)) => literal
+      case _ =>
+        c.abort(
+          code.pos,
+          "cannot compile dynamic expressions, only constant literals.\n" +
+            "To fix this problem, pass in a string literal in double quotes \"...\""
+        )
+    }
+
+    def formatError(message: String, pos: scala.reflect.api.Position): String =
+      new StringBuilder()
+        .append("error:")
+        .append(if (message.contains('\n')) "\n" else " ")
+        .append(message)
+        .append("\n")
+        .append(pos.lineContent)
+        .append("\n")
+        .append(" " * (pos.column - 1))
+        .append("^")
+        .toString()
+
+    val message: String =
+      try {
+        c.typecheck(c.parse(s"{\n$toParse\n}"))
+        ""
+      } catch {
+        case e: ParseException =>
+          formatError(e.getMessage(), e.pos)
+        case e: TypecheckException =>
+          formatError(e.getMessage(), e.pos)
+      }
+    Literal(Constant(message))
   }
 
 }

--- a/munit/shared/src/main/scala-3.0.0-M2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3.0.0-M2/munit/internal/MacroCompat.scala
@@ -12,14 +12,7 @@ object MacroCompat {
 
   trait LocationMacro {
     inline implicit def generate: Location = ${ locationImpl() }
-    implicit def generate: Location = macro locationImplScala2
-  }
-
-  def locationImplScala2(c: Context): c.Tree = {
-    import c.universe._
-    val line = Literal(Constant(c.enclosingPosition.line))
-    val path = Literal(Constant(c.enclosingPosition.source.path))
-    New(c.mirror.staticClass(classOf[Location].getName()), path, line)
+    implicit def generate: Location = macro MacroCompatScala2.locationImpl
   }
 
   def locationImpl()(using Quotes): Expr[Location] = {
@@ -32,7 +25,7 @@ object MacroCompat {
 
   trait ClueMacro {
     inline implicit def generate[T](value: T): Clue[T] = ${ clueImpl('value) }
-    implicit def generate[T](value: T): Clue[T] = macro clueImplScala2
+    implicit def generate[T](value: T): Clue[T] = macro MacroCompatScala2.clueImpl
   }
 
   def clueImpl[T: Type](value: Expr[T])(using Quotes): Expr[Clue[T]] = {
@@ -40,44 +33,6 @@ object MacroCompat {
     val source = Term.of(value).pos.sourceCode
     val valueType = Type.show[T]
     '{ new Clue(${Expr(source)}, $value, ${Expr(valueType)}) }
-  }
-
-  def clueImplScala2(c: Context)(value: c.Tree): c.Tree = {
-    import c.universe._
-    import compat._
-    val text: String =
-      if (value.pos != null && value.pos.isRange) {
-        val chars = value.pos.source.content
-        val start = value.pos.start
-        val end = value.pos.end
-        if (
-          end > start &&
-          start >= 0 && start < chars.length &&
-          end >= 0 && end < chars.length
-        ) {
-          new String(chars, start, end - start)
-        } else {
-          ""
-        }
-      } else {
-        ""
-      }
-    def simplifyType(tpe: Type): Type = tpe match {
-      case TypeRef(ThisType(pre), sym, args) if pre == sym.owner =>
-        simplifyType(TypeRef(NoPrefix, sym, args))
-      case t =>
-        // uncomment to debug:
-        // Printers.log(t)(Location.empty)
-        t.widen
-    }
-    val source = Literal(Constant(text))
-    val valueType = Literal(Constant(simplifyType(value.tpe).toString()))
-    New(
-      TypeRef(NoPrefix, c.mirror.staticClass(classOf[Clue[_]].getName), List(value.tpe.widen)),
-      source,
-      value,
-      valueType
-    )
   }
 
   trait CompileErrorMacro {
@@ -93,44 +48,8 @@ object MacroCompat {
         s"error:${separator}${trimMessage}\n${error.lineContent}\n${indent}^"
       }.mkString("\n")
     }
-    def compileErrors(code: String): String = macro compileErrorsImplScala2
+    def compileErrors(code: String): String = macro MacroCompatScala2.compileErrorsImpl
   }
 
-  def compileErrorsImplScala2(c: Context)(code: c.Tree): c.Tree = {
-    import c.universe._
-    val toParse: String = code match {
-      case Literal(Constant(literal: String)) => literal
-      case _ =>
-        c.abort(
-          code.pos,
-          "cannot compile dynamic expressions, only constant literals.\n" +
-            "To fix this problem, pass in a string literal in double quotes \"...\""
-        )
-    }
-
-    def formatError(message: String, pos: scala.reflect.api.Position): String =
-      new StringBuilder()
-        .append("error:")
-        .append(if (message.contains('\n')) "\n" else " ")
-        .append(message)
-        .append("\n")
-        .append(pos.lineContent)
-        .append("\n")
-        .append(" " * (pos.column - 1))
-        .append("^")
-        .toString()
-
-    val message: String =
-      try {
-        c.typecheck(c.parse(s"{\n$toParse\n}"))
-        ""
-      } catch {
-        case e: ParseException =>
-          formatError(e.getMessage(), e.pos)
-        case e: TypecheckException =>
-          formatError(e.getMessage(), e.pos)
-      }
-    Literal(Constant(message))
-  }
 
 }

--- a/munit/shared/src/main/scala-3.0.0-M3/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3.0.0-M3/munit/internal/MacroCompat.scala
@@ -4,9 +4,6 @@ import munit.Clue
 import munit.Location
 import scala.quoted._
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox.Context
-import scala.reflect.macros.TypecheckException
-import scala.reflect.macros.ParseException
 
 object MacroCompat {
 

--- a/munit/shared/src/main/scala-3.0.0-M3/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3.0.0-M3/munit/internal/MacroCompat.scala
@@ -3,11 +3,16 @@ package munit.internal
 import munit.Clue
 import munit.Location
 import scala.quoted._
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+import scala.reflect.macros.TypecheckException
+import scala.reflect.macros.ParseException
 
 object MacroCompat {
 
   trait LocationMacro {
     inline implicit def generate: Location = ${ locationImpl() }
+    implicit def generate: Location = macro locationImplScala2
   }
 
   def locationImpl()(using Quotes): Expr[Location] = {
@@ -18,8 +23,16 @@ object MacroCompat {
     '{ new Location(${Expr(path)}, ${Expr(startLine)}) }
   }
 
+  def locationImplScala2(c: Context): c.Tree = {
+    import c.universe._
+    val line = Literal(Constant(c.enclosingPosition.line))
+    val path = Literal(Constant(c.enclosingPosition.source.path))
+    New(c.mirror.staticClass(classOf[Location].getName()), path, line)
+  }
+
   trait ClueMacro {
     inline implicit def generate[T](value: T): Clue[T] = ${ clueImpl('value) }
+    implicit def generate[T](value: T): Clue[T] = macro clueImplScala2
   }
 
   def clueImpl[T: Type](value: Expr[T])(using Quotes): Expr[Clue[T]] = {
@@ -27,6 +40,44 @@ object MacroCompat {
     val source = Term.of(value).pos.sourceCode.getOrElse("")
     val valueType = TypeTree.of[T].show(using Printer.TreeShortCode)
     '{ new Clue(${Expr(source)}, $value, ${Expr(valueType)}) }
+  }
+
+  def clueImplScala2(c: Context)(value: c.Tree): c.Tree = {
+    import c.universe._
+    import compat._
+    val text: String =
+      if (value.pos != null && value.pos.isRange) {
+        val chars = value.pos.source.content
+        val start = value.pos.start
+        val end = value.pos.end
+        if (
+          end > start &&
+          start >= 0 && start < chars.length &&
+          end >= 0 && end < chars.length
+        ) {
+          new String(chars, start, end - start)
+        } else {
+          ""
+        }
+      } else {
+        ""
+      }
+    def simplifyType(tpe: Type): Type = tpe match {
+      case TypeRef(ThisType(pre), sym, args) if pre == sym.owner =>
+        simplifyType(TypeRef(NoPrefix, sym, args))
+      case t =>
+        // uncomment to debug:
+        // Printers.log(t)(Location.empty)
+        t.widen
+    }
+    val source = Literal(Constant(text))
+    val valueType = Literal(Constant(simplifyType(value.tpe).toString()))
+    New(
+      TypeRef(NoPrefix, c.mirror.staticClass(classOf[Clue[_]].getName), List(value.tpe.widen)),
+      source,
+      value,
+      valueType
+    )
   }
 
   trait CompileErrorMacro {
@@ -42,6 +93,44 @@ object MacroCompat {
         s"error:${separator}${trimMessage}\n${error.lineContent}\n${indent}^"
       }.mkString("\n")
     }
+    def compileErrors(code: String): String = macro compileErrorsImplScala2
+  }
+
+  def compileErrorsImplScala2(c: Context)(code: c.Tree): c.Tree = {
+    import c.universe._
+    val toParse: String = code match {
+      case Literal(Constant(literal: String)) => literal
+      case _ =>
+        c.abort(
+          code.pos,
+          "cannot compile dynamic expressions, only constant literals.\n" +
+            "To fix this problem, pass in a string literal in double quotes \"...\""
+        )
+    }
+
+    def formatError(message: String, pos: scala.reflect.api.Position): String =
+      new StringBuilder()
+        .append("error:")
+        .append(if (message.contains('\n')) "\n" else " ")
+        .append(message)
+        .append("\n")
+        .append(pos.lineContent)
+        .append("\n")
+        .append(" " * (pos.column - 1))
+        .append("^")
+        .toString()
+
+    val message: String =
+      try {
+        c.typecheck(c.parse(s"{\n$toParse\n}"))
+        ""
+      } catch {
+        case e: ParseException =>
+          formatError(e.getMessage(), e.pos)
+        case e: TypecheckException =>
+          formatError(e.getMessage(), e.pos)
+      }
+    Literal(Constant(message))
   }
 
 }

--- a/munit/shared/src/main/scala-3.0.0-M3/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3.0.0-M3/munit/internal/MacroCompat.scala
@@ -12,7 +12,7 @@ object MacroCompat {
 
   trait LocationMacro {
     inline implicit def generate: Location = ${ locationImpl() }
-    implicit def generate: Location = macro locationImplScala2
+    implicit def generate: Location = macro MacroCompatScala2.locationImpl
   }
 
   def locationImpl()(using Quotes): Expr[Location] = {
@@ -23,16 +23,9 @@ object MacroCompat {
     '{ new Location(${Expr(path)}, ${Expr(startLine)}) }
   }
 
-  def locationImplScala2(c: Context): c.Tree = {
-    import c.universe._
-    val line = Literal(Constant(c.enclosingPosition.line))
-    val path = Literal(Constant(c.enclosingPosition.source.path))
-    New(c.mirror.staticClass(classOf[Location].getName()), path, line)
-  }
-
   trait ClueMacro {
     inline implicit def generate[T](value: T): Clue[T] = ${ clueImpl('value) }
-    implicit def generate[T](value: T): Clue[T] = macro clueImplScala2
+    implicit def generate[T](value: T): Clue[T] = macro MacroCompatScala2.clueImpl
   }
 
   def clueImpl[T: Type](value: Expr[T])(using Quotes): Expr[Clue[T]] = {
@@ -42,43 +35,6 @@ object MacroCompat {
     '{ new Clue(${Expr(source)}, $value, ${Expr(valueType)}) }
   }
 
-  def clueImplScala2(c: Context)(value: c.Tree): c.Tree = {
-    import c.universe._
-    import compat._
-    val text: String =
-      if (value.pos != null && value.pos.isRange) {
-        val chars = value.pos.source.content
-        val start = value.pos.start
-        val end = value.pos.end
-        if (
-          end > start &&
-          start >= 0 && start < chars.length &&
-          end >= 0 && end < chars.length
-        ) {
-          new String(chars, start, end - start)
-        } else {
-          ""
-        }
-      } else {
-        ""
-      }
-    def simplifyType(tpe: Type): Type = tpe match {
-      case TypeRef(ThisType(pre), sym, args) if pre == sym.owner =>
-        simplifyType(TypeRef(NoPrefix, sym, args))
-      case t =>
-        // uncomment to debug:
-        // Printers.log(t)(Location.empty)
-        t.widen
-    }
-    val source = Literal(Constant(text))
-    val valueType = Literal(Constant(simplifyType(value.tpe).toString()))
-    New(
-      TypeRef(NoPrefix, c.mirror.staticClass(classOf[Clue[_]].getName), List(value.tpe.widen)),
-      source,
-      value,
-      valueType
-    )
-  }
 
   trait CompileErrorMacro {
     inline def compileErrors(inline code: String): String = {
@@ -93,44 +49,7 @@ object MacroCompat {
         s"error:${separator}${trimMessage}\n${error.lineContent}\n${indent}^"
       }.mkString("\n")
     }
-    def compileErrors(code: String): String = macro compileErrorsImplScala2
-  }
-
-  def compileErrorsImplScala2(c: Context)(code: c.Tree): c.Tree = {
-    import c.universe._
-    val toParse: String = code match {
-      case Literal(Constant(literal: String)) => literal
-      case _ =>
-        c.abort(
-          code.pos,
-          "cannot compile dynamic expressions, only constant literals.\n" +
-            "To fix this problem, pass in a string literal in double quotes \"...\""
-        )
-    }
-
-    def formatError(message: String, pos: scala.reflect.api.Position): String =
-      new StringBuilder()
-        .append("error:")
-        .append(if (message.contains('\n')) "\n" else " ")
-        .append(message)
-        .append("\n")
-        .append(pos.lineContent)
-        .append("\n")
-        .append(" " * (pos.column - 1))
-        .append("^")
-        .toString()
-
-    val message: String =
-      try {
-        c.typecheck(c.parse(s"{\n$toParse\n}"))
-        ""
-      } catch {
-        case e: ParseException =>
-          formatError(e.getMessage(), e.pos)
-        case e: TypecheckException =>
-          formatError(e.getMessage(), e.pos)
-      }
-    Literal(Constant(message))
+    def compileErrors(code: String): String = macro MacroCompatScala2.compileErrorsImpl
   }
 
 }

--- a/munit/shared/src/main/scala/munit/internal/MacroCompatScala2.scala
+++ b/munit/shared/src/main/scala/munit/internal/MacroCompatScala2.scala
@@ -1,0 +1,95 @@
+package munit.internal
+
+import munit.Clue
+import munit.Location
+import scala.reflect.macros.blackbox.Context
+import scala.reflect.macros.TypecheckException
+import scala.reflect.macros.ParseException
+
+object MacroCompatScala2 {
+
+  def locationImpl(c: Context): c.Tree = {
+    import c.universe._
+    val line = Literal(Constant(c.enclosingPosition.line))
+    val path = Literal(Constant(c.enclosingPosition.source.path))
+    New(c.mirror.staticClass(classOf[Location].getName()), path, line)
+  }
+
+  def clueImpl(c: Context)(value: c.Tree): c.Tree = {
+    import c.universe._
+    val text: String =
+      if (value.pos != null && value.pos.isRange) {
+        val chars = value.pos.source.content
+        val start = value.pos.start
+        val end = value.pos.end
+        if (
+          end > start &&
+          start >= 0 && start < chars.length &&
+          end >= 0 && end < chars.length
+        ) {
+          new String(chars, start, end - start)
+        } else {
+          ""
+        }
+      } else {
+        ""
+      }
+    def simplifyType(tpe: Type): Type = tpe match {
+      case TypeRef(ThisType(pre), sym, args) if pre == sym.owner =>
+        simplifyType(c.internal.typeRef(NoPrefix, sym, args))
+      case t =>
+        // uncomment to debug:
+        // Printers.log(t)(Location.empty)
+        t.widen
+    }
+    val source = Literal(Constant(text))
+    val valueType = Literal(Constant(simplifyType(value.tpe).toString()))
+    New(
+      c.internal.typeRef(
+        NoPrefix,
+        c.mirror.staticClass(classOf[Clue[_]].getName()),
+        List(value.tpe.widen)
+      ),
+      source,
+      value,
+      valueType
+    )
+  }
+
+  def compileErrorsImpl(c: Context)(code: c.Tree): c.Tree = {
+    import c.universe._
+    val toParse: String = code match {
+      case Literal(Constant(literal: String)) => literal
+      case _ =>
+        c.abort(
+          code.pos,
+          "cannot compile dynamic expressions, only constant literals.\n" +
+            "To fix this problem, pass in a string literal in double quotes \"...\""
+        )
+    }
+
+    def formatError(message: String, pos: scala.reflect.api.Position): String =
+      new StringBuilder()
+        .append("error:")
+        .append(if (message.contains('\n')) "\n" else " ")
+        .append(message)
+        .append("\n")
+        .append(pos.lineContent)
+        .append("\n")
+        .append(" " * (pos.column - 1))
+        .append("^")
+        .toString()
+
+    val message: String =
+      try {
+        c.typecheck(c.parse(s"{\n$toParse\n}"))
+        ""
+      } catch {
+        case e: ParseException =>
+          formatError(e.getMessage(), e.pos)
+        case e: TypecheckException =>
+          formatError(e.getMessage(), e.pos)
+      }
+    Literal(Constant(message))
+  }
+}

--- a/munit/shared/src/main/scala/munit/internal/console/Printers.scala
+++ b/munit/shared/src/main/scala/munit/internal/console/Printers.scala
@@ -207,7 +207,7 @@ object Printers {
     var i = 0
     while (i < string.length()) {
       val ch = string.charAt(i)
-      (ch: @switch) match {
+      ch match {
         case '"' | '\'' => out.append(ch)
         case _          => printChar(ch, out, isEscapeUnicode = false)
       }

--- a/website/blog/2021-01-05-macromix.md
+++ b/website/blog/2021-01-05-macromix.md
@@ -1,0 +1,183 @@
+---
+author: Ólafur Páll Geirsson
+title: Publish Scala 2 and Scala 3 macros together
+authorURL: https://twitter.com/olafurpg
+authorImageURL: https://github.com/olafurpg.png
+---
+
+The next release of MUnit makes use of a new compiler feature that allows you to
+publish Scala 2 and Scala 3 macros together in a single artifact. The blog post
+[Forward Compatibility for the Scala 3 Transition](https://www.scala-lang.org/blog/2020/11/19/scala-3-forward-compat.html)
+by Jamie Thompson explains this feature in more detail. The
+[Scala 3 Migration Guide](https://scalacenter.github.io/scala-3-migration-guide/docs/macros/migration-tutorial.html#mixing-macro-definitions)
+contains a hands-on tutorial on how to use this feature. In this post, I want to
+share a small example to motivate why I think this feature will be critical for
+a smooth Scala 3 transition.
+
+> This blog post was written as part of a collaboration with the Scala Center.
+
+While it's standard practice to cross-build a Scala library between 2.12 and
+2.13, you should think twice before cross-building for Scala 2.13 and Scala 3.
+There is a chance you can skip 2.13 and publish only for Scala 3 instead. The
+reason you may want to skip 2.13 is to prevent unexpected runtime crashes.
+
+To demonstrate how runtime crashes can happen, consider the following dependency
+graph for a Scala 3 application.
+
+<!-- prettier-ignore-start -->
+<div style="text-align:center">
+<svg width="268pt" height="188pt"
+ viewBox="0.00 0.00 267.89 188.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 184)">
+<title>G</title>
+<polygon fill="white" stroke="transparent" points="-4,4 -4,-184 263.89,-184 263.89,4 -4,4"/>
+<!-- app_3.0 -->
+<g id="node1" class="node">
+<title>app_3.0</title>
+<ellipse fill="none" stroke="black" cx="126.84" cy="-162" rx="38.99" ry="18"/>
+<text text-anchor="middle" x="126.84" y="-158.3" font-family="Times,serif" font-size="14.00">app_3.0</text>
+</g>
+<!-- a_library_3.0 -->
+<g id="node2" class="node">
+<title>a_library_3.0</title>
+<ellipse fill="none" stroke="black" cx="57.84" cy="-90" rx="57.69" ry="18"/>
+<text text-anchor="middle" x="57.84" y="-86.3" font-family="Times,serif" font-size="14.00">a_library_3.0</text>
+</g>
+<!-- app_3.0&#45;&gt;a_library_3.0 -->
+<g id="edge1" class="edge">
+<title>app_3.0&#45;&gt;a_library_3.0</title>
+<path fill="none" stroke="black" d="M111.19,-145.12C102.32,-136.12 91.05,-124.68 81.15,-114.65"/>
+<polygon fill="black" stroke="black" points="83.43,-111.97 73.92,-107.31 78.45,-116.89 83.43,-111.97"/>
+</g>
+<!-- b_library_2.13 -->
+<g id="node4" class="node">
+<title>b_library_2.13</title>
+<ellipse fill="none" stroke="black" cx="196.84" cy="-90" rx="63.09" ry="18"/>
+<text text-anchor="middle" x="196.84" y="-86.3" font-family="Times,serif" font-size="14.00">b_library_2.13</text>
+</g>
+<!-- app_3.0&#45;&gt;b_library_2.13 -->
+<g id="edge3" class="edge">
+<title>app_3.0&#45;&gt;b_library_2.13</title>
+<path fill="none" stroke="black" d="M142.38,-145.46C151.46,-136.39 163.09,-124.75 173.28,-114.57"/>
+<polygon fill="black" stroke="black" points="175.78,-117.01 180.38,-107.47 170.83,-112.06 175.78,-117.01"/>
+</g>
+<!-- munit_3.0 -->
+<g id="node3" class="node">
+<title>munit_3.0</title>
+<ellipse fill="none" stroke="black" cx="57.84" cy="-18" rx="47.39" ry="18"/>
+<text text-anchor="middle" x="57.84" y="-14.3" font-family="Times,serif" font-size="14.00">munit_3.0</text>
+</g>
+<!-- a_library_3.0&#45;&gt;munit_3.0 -->
+<g id="edge2" class="edge">
+<title>a_library_3.0&#45;&gt;munit_3.0</title>
+<path fill="none" stroke="black" d="M57.84,-71.7C57.84,-63.98 57.84,-54.71 57.84,-46.11"/>
+<polygon fill="black" stroke="black" points="61.34,-46.1 57.84,-36.1 54.34,-46.1 61.34,-46.1"/>
+</g>
+<!-- munit_2.13 -->
+<g id="node5" class="node">
+<title>munit_2.13</title>
+<ellipse fill="none" stroke="black" cx="196.84" cy="-18" rx="51.99" ry="18"/>
+<text text-anchor="middle" x="196.84" y="-14.3" font-family="Times,serif" font-size="14.00">munit_2.13</text>
+</g>
+<!-- b_library_2.13&#45;&gt;munit_2.13 -->
+<g id="edge4" class="edge">
+<title>b_library_2.13&#45;&gt;munit_2.13</title>
+<path fill="none" stroke="black" d="M196.84,-71.7C196.84,-63.98 196.84,-54.71 196.84,-46.11"/>
+<polygon fill="black" stroke="black" points="200.34,-46.1 196.84,-36.1 193.34,-46.1 200.34,-46.1"/>
+</g>
+</g>
+</svg>
+
+</div>
+<!-- prettier-ignore-end -->
+
+The application has two direct dependencies (`a_library_3.0`, `b_library_2.13`)
+and one transitive dependency on MUnit. The problem is that the transitive MUnit
+dependency appears twice on the classpath: once for Scala 3 (`munit_3.0`) and
+once for Scala 2.13 (`munit_2.13`). If `munit_3.0` and `munit_2.13` have binary
+incompatibilities then the application may compile successfully but crash at
+runtime with a `MethodNotFoundException` or `ClassNotFoundException`.
+
+The next release of MUnit avoids this problem by including Scala 2 macros in the
+`munit_3.0` artifact. With this change, `b_library_2.13` can depend on
+`munit_3.0` and the dependency graph becomes like this instead.
+
+<!-- prettier-ignore-start -->
+<div style="text-align:center">
+<svg width="268pt" height="188pt"
+ viewBox="0.00 0.00 267.89 188.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 184)">
+<title>G</title>
+<polygon fill="white" stroke="transparent" points="-4,4 -4,-184 263.89,-184 263.89,4 -4,4"/>
+<!-- app_3.0 -->
+<g id="node1" class="node">
+<title>app_3.0</title>
+<ellipse fill="none" stroke="black" cx="126.84" cy="-162" rx="38.99" ry="18"/>
+<text text-anchor="middle" x="126.84" y="-158.3" font-family="Times,serif" font-size="14.00">app_3.0</text>
+</g>
+<!-- a_library_3.0 -->
+<g id="node2" class="node">
+<title>a_library_3.0</title>
+<ellipse fill="none" stroke="black" cx="57.84" cy="-90" rx="57.69" ry="18"/>
+<text text-anchor="middle" x="57.84" y="-86.3" font-family="Times,serif" font-size="14.00">a_library_3.0</text>
+</g>
+<!-- app_3.0&#45;&gt;a_library_3.0 -->
+<g id="edge1" class="edge">
+<title>app_3.0&#45;&gt;a_library_3.0</title>
+<path fill="none" stroke="black" d="M111.19,-145.12C102.32,-136.12 91.05,-124.68 81.15,-114.65"/>
+<polygon fill="black" stroke="black" points="83.43,-111.97 73.92,-107.31 78.45,-116.89 83.43,-111.97"/>
+</g>
+<!-- b_library_2.13 -->
+<g id="node4" class="node">
+<title>b_library_2.13</title>
+<ellipse fill="none" stroke="black" cx="196.84" cy="-90" rx="63.09" ry="18"/>
+<text text-anchor="middle" x="196.84" y="-86.3" font-family="Times,serif" font-size="14.00">b_library_2.13</text>
+</g>
+<!-- app_3.0&#45;&gt;b_library_2.13 -->
+<g id="edge3" class="edge">
+<title>app_3.0&#45;&gt;b_library_2.13</title>
+<path fill="none" stroke="black" d="M142.38,-145.46C151.46,-136.39 163.09,-124.75 173.28,-114.57"/>
+<polygon fill="black" stroke="black" points="175.78,-117.01 180.38,-107.47 170.83,-112.06 175.78,-117.01"/>
+</g>
+<!-- munit_3.0 -->
+<g id="node3" class="node">
+<title>munit_3.0</title>
+<ellipse fill="none" stroke="black" cx="126.84" cy="-18" rx="47.39" ry="18"/>
+<text text-anchor="middle" x="126.84" y="-14.3" font-family="Times,serif" font-size="14.00">munit_3.0</text>
+</g>
+<!-- a_library_3.0&#45;&gt;munit_3.0 -->
+<g id="edge2" class="edge">
+<title>a_library_3.0&#45;&gt;munit_3.0</title>
+<path fill="none" stroke="black" d="M74.2,-72.41C83.09,-63.39 94.23,-52.09 103.97,-42.21"/>
+<polygon fill="black" stroke="black" points="106.56,-44.57 111.09,-34.99 101.57,-39.65 106.56,-44.57"/>
+</g>
+<!-- b_library_2.13&#45;&gt;munit_3.0 -->
+<g id="edge4" class="edge">
+<title>b_library_2.13&#45;&gt;munit_3.0</title>
+<path fill="none" stroke="black" d="M180.26,-72.41C171.23,-63.39 159.93,-52.09 150.05,-42.21"/>
+<polygon fill="black" stroke="black" points="152.38,-39.58 142.83,-34.99 147.43,-44.53 152.38,-39.58"/>
+</g>
+</g>
+</svg>
+</div>
+<!-- prettier-ignore-end -->
+
+This change is possible thanks to the new `-Ytasty-reader` flag in the Scala
+2.13.4 compiler that enables the Scala 2 compiler to read Scala 3 libraries.
+
+This feature is new and has some limitations that's good to be aware of:
+
+- Scala 2.13.4 can only understand libraries that are published with the old
+  Scala 3.0.0-M1 version (latest is 3.0.0-M3 at the time of this writing). The
+  upcoming Scala 2.13.5 release will be able to understand newer Scala 3.x
+  releases.
+- Some common features in Scala 2 macros don't work in Scala 3. Most notably,
+  you can't use quasiquotes or macro bundles. In the case of MUnit, we had to
+  replace `typeOf[Location]` with
+  `c.mirror.staticClass(classOf[Location].getName)` because `typeOf` is itself
+  implemented as a Scala 2 macro.
+- Your Scala 3 library needs a compile-time dependecy on `scala-reflect:2.13.x`,
+
+Nevertheless, it's a phenomenal achievement that it's at all possible to publish
+Scala 2 and Scala 3 macros together. For certain libraries, I'm optimistic this
+feature will be a critical component to smoothen the Scala 3 transition.

--- a/website/blog/2021-01-05-macromix.md
+++ b/website/blog/2021-01-05-macromix.md
@@ -178,6 +178,7 @@ This feature is new and has some limitations that's good to be aware of:
   implemented as a Scala 2 macro.
 - Your Scala 3 library needs a compile-time dependecy on `scala-reflect:2.13.x`,
 
-Nevertheless, it's a phenomenal achievement that it's at all possible to publish
-Scala 2 and Scala 3 macros together. For certain libraries, I'm optimistic this
-feature will be a critical component to smoothen the Scala 3 transition.
+Given these limitations, MUnit will continue to publish for 2.13. Nevertheless,
+it's a phenomenal achievement that it's at all possible to publish Scala 2 and
+Scala 3 macros together. For certain libraries, I'm optimistic this feature will
+be a critical component to smoothen the Scala 3 transition.

--- a/website/blog/2021-01-05-macromix.md
+++ b/website/blog/2021-01-05-macromix.md
@@ -172,10 +172,9 @@ This feature is new and has some limitations that's good to be aware of:
   upcoming Scala 2.13.5 release will be able to understand newer Scala 3.x
   releases.
 - Some common features in Scala 2 macros don't work in Scala 3. Most notably,
-  you can't use quasiquotes or macro bundles. In the case of MUnit, we had to
-  replace `typeOf[Location]` with
-  `c.mirror.staticClass(classOf[Location].getName)` because `typeOf` is itself
-  implemented as a Scala 2 macro.
+  you can't use quasiquotes. In the case of MUnit, we had to replace
+  `typeOf[Location]` with `c.mirror.staticClass(classOf[Location].getName)`
+  because `typeOf` is itself implemented as a Scala 2 macro.
 - Your Scala 3 library needs a compile-time dependecy on `scala-reflect:2.13.x`,
 
 Given these limitations, MUnit will continue to publish for 2.13. Nevertheless,


### PR DESCRIPTION
With this change, Scala 2.13 users will be able to depend on munit_3.0
artifacts instead of munit_2.13.

I wasn't able to manually test this change because MUnit doesn't
cross-build for 3.0.0-M1, which is the latest version supported by the
`-Ytasty-reader` flag in 2.13.4. Once 2.13.5 is out, it will be easier
ot make use of this feature.