### PR TITLE
Update Scala versions to 2.12.13 and 2.13.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ import scala.collection.mutable
 val scalaJSVersion = "1.4.0"
 val scalaNativeVersion = "0.4.0-M2"
 def previousVersion = "0.7.0"
-def scala213 = "2.13.2"
-def scala212 = "2.12.11"
+def scala213 = "2.13.4"
+def scala212 = "2.12.13"
 def scala211 = "2.11.12"
 def scala3Stable = "3.0.0-M3"
 def scala3Previous = List("3.0.0-M2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.15")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.16")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.4")
 addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.6")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.25")


### PR DESCRIPTION
It seems that the release is failing due to the changes in mdoc I did where we now release:
`mdoc_2.11`, `mdoc_2.12.12`, `mdoc_2.12` and `mdoc_2.13`, where `mdoc_2.12.12` was added to support Scala versions prior to 2.12.13 due to binary incompatibility.

Somehow when using Scala 2.12.11 it actually needs `mdoc-runtime_2.12.11`, which seems to be a bug in coursier. I reported it here: https://github.com/sbt/sbt/issues/6269

This fixes the issue, but I need to investigate a bit further and will try to work around it in mdoc.