### PR TITLE
Release for Scala 3.0.0-RC3

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -9,8 +9,8 @@ coursier resolve \
   org.scalameta:munit_2.11:$version \
   org.scalameta:munit_2.12:$version \
   org.scalameta:munit_2.13:$version \
-  org.scalameta:munit_3.0.0-RC1:$version \
   org.scalameta:munit_3.0.0-RC2:$version \
+  org.scalameta:munit_3.0.0-RC3:$version \
   org.scalameta:munit_native0.4_2.11:$version \
   org.scalameta:munit_native0.4_2.12:$version \
   org.scalameta:munit_native0.4_2.13:$version \
@@ -20,8 +20,8 @@ coursier resolve \
   org.scalameta:munit-scalacheck_2.11:$version \
   org.scalameta:munit-scalacheck_2.12:$version \
   org.scalameta:munit-scalacheck_2.13:$version \
-  org.scalameta:munit-scalacheck_3.0.0-RC1:$version \
   org.scalameta:munit-scalacheck_3.0.0-RC2:$version \
+  org.scalameta:munit-scalacheck_3.0.0-RC3:$version \
   org.scalameta:munit-scalacheck_native0.4_2.11:$version \
   org.scalameta:munit-scalacheck_native0.4_2.12:$version \
   org.scalameta:munit-scalacheck_native0.4_2.13:$version \

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ def previousVersion = "0.7.0"
 def scala213 = "2.13.4"
 def scala212 = "2.12.13"
 def scala211 = "2.11.12"
-def scala3Stable = "3.0.0-RC2"
-def scala3Previous = List("3.0.0-RC1")
+def scala3Stable = "3.0.0-RC3"
+def scala3Previous = List("3.0.0-RC2")
 def junitVersion = "4.13.2"
 def gcp = "com.google.cloud" % "google-cloud-storage" % "1.113.14"
 inThisBuild(

--- a/tests/shared/src/test/scala/munit/ClueSuite.scala
+++ b/tests/shared/src/test/scala/munit/ClueSuite.scala
@@ -17,7 +17,7 @@ class ClueSuite extends BaseSuite {
 
   // Disabled on Dotty because the starting position doesn't include opening "("
   check(
-    "lambda".tag(NoDotty),
+    "lambda",
     { (y: String) => y.head },
     "(y: String) => y.head"
   )
@@ -83,7 +83,7 @@ class ClueSuite extends BaseSuite {
       clues: Clues,
       expected: String
   )(implicit loc: Location): Unit = {
-    test(options.tag(NoDotty)) {
+    test(options) {
       val obtained = munitPrint(clues)
       assertNoDiff(obtained, expected)
     }

--- a/tests/shared/src/test/scala/munit/TypeCheckSuite.scala
+++ b/tests/shared/src/test/scala/munit/TypeCheckSuite.scala
@@ -57,17 +57,7 @@ class TypeCheckSuite extends FunSuite {
                 |val x: = 2
                 |       ^
                 |""".stripMargin,
-      "3.0.0-RC1" ->
-        // NOTE(olafur): I'm not sure what's going on with the second errors but
-        // that's what Dotty reports.
-        """|error: an identifier expected, but '=' found
-           |val x: = 2
-           |      ^
-           |error: Declaration of value x not allowed here: only classes can have declared but undefined members
-           |package munit
-           |   ^
-           |""".stripMargin,
-      "3.0.0-RC2" ->
+      "3" ->
         """|error: an identifier expected, but '=' found
            |val x: = 2
            |      ^


### PR DESCRIPTION
Closes #350 

Also removes 3.0.0-RC1 support /cc @tgodzik 

I've also re-enabled 2 out of 3 tests that were ignored on Scala 3, since they pass now 🎉