### PR TITLE
Attempt 1: make sure to always flush buffered logs

### DIFF
--- a/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
@@ -159,7 +159,6 @@ final class EventDispatcher extends RunListener
           ", " +
           result.getIgnoreCount()+" ignored" +
           ", "+result.getRunCount()+" total, "+(result.getRunTime()/1000.0)+"s") ;
-        logger.flush();
       }
     runStatistics.addTime(result.getRunTime());
   }
@@ -174,7 +173,6 @@ final class EventDispatcher extends RunListener
   {
       if (settings.verbose) {
         logger.info(taskInfo + " started");
-        logger.flush();
       }
   }
 
@@ -183,7 +181,6 @@ final class EventDispatcher extends RunListener
     post(new Event(Ansi.c(testName, Ansi.ERRMSG), settings.buildErrorMessage(err), Status.Error, 0L, err) {
       void logTo(RichLogger logger) {
         logger.error(ansiName+" failed: "+ansiMsg, error);
-        logger.flush();
       }
     });
   }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitTask.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitTask.java
@@ -79,6 +79,7 @@ final class JUnitTask implements Task {
         ed.testExecutionFailed(testClassName, ex);
       }
     } finally {
+      logger.flush();
       settings.restoreSystemProperties(oldprops);
     }
     return new Task[0]; // junit tests do not nest


### PR DESCRIPTION
Previously, buffered logs would sometimes not get flushed resulting in
lost test report output. See #408. This commit adds an extra attempt to
flush the buffered logs inside the sbt testing framework in case the
logs don't get flushed by the JUnit test listener. I'm not 100% sure
this fixes the problem but it seems worth a short and it shouldn't cause
a regression.