### PR TITLE
More correct string inequality error message

### DIFF
--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -153,11 +153,18 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
           munitPrint(clue),
           printObtainedAsStripMargin = false
         )
-        failComparison(
-          s"values are not equal even if they have the same `toString()`: $obtained",
-          obtained,
-          expected
-        )
+        if (obtained.toString() == expected.toString())
+          failComparison(
+            s"values are not equal even if they have the same `toString()`: $obtained",
+            obtained,
+            expected
+          )
+        else
+          failComparison(
+            s"values are not equal, even if their text representation only differs in leading/trailing whitespace and ANSI escape characters: $obtained",
+            obtained,
+            expected
+          )
       }
     }
   }

--- a/tests/shared/src/main/scala/munit/AssertionsFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/AssertionsFrameworkSuite.scala
@@ -34,6 +34,10 @@ class AssertionsFrameworkSuite extends FunSuite {
     }
     assertEquals[Any, Any](a.A(), b.A())
   }
+
+  test("toString-has-different-whitespace") {
+    assertEquals[Any, Any]("foo", "foo  ")
+  }
 }
 
 object AssertionsFrameworkSuite
@@ -57,5 +61,9 @@ object AssertionsFrameworkSuite
          |=> Diff (- obtained, + expected)
          |-a.A()
          |+b.B()
+         |==> failure munit.AssertionsFrameworkSuite.toString-has-different-whitespace - /scala/munit/AssertionsFrameworkSuite.scala:39 values are not equal, even if their text representation only differs in leading/trailing whitespace and ANSI escape characters: foo
+         |38:  test("toString-has-different-whitespace") {
+         |39:    assertEquals[Any, Any]("foo", "foo  ")
+         |40:  }
          |""".stripMargin
     )


### PR DESCRIPTION
The current logic may claim values have the same `toString()`
when they don't. The 'full' solution would of course be to
have a 'strict' string diff, but until then let's at least
not lie about it.

Fixes #152