### PR TITLE
Introduce `BaseFunSuite` trait and make `FunSuite` an empty class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,6 +103,18 @@ lazy val mimaEnable: List[Def.Setting[_]] = List(
     ProblemFilters.exclude[MissingClassProblem]("munit.Suite$Fixture"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem](
       "munit.TestTransforms#TestTransform.apply"
+    ),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "munit.FunFixtures#FunFixture.this"
+    ),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "munit.SuiteTransforms#SuiteTransform.this"
+    ),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "munit.TestTransforms#TestTransform.this"
+    ),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem](
+      "munit.ValueTransforms#ValueTransform.this"
     )
   ),
   mimaPreviousArtifacts := {

--- a/munit/shared/src/main/scala/munit/FunFixtures.scala
+++ b/munit/shared/src/main/scala/munit/FunFixtures.scala
@@ -6,7 +6,7 @@ import scala.concurrent.Future
 import scala.util.Success
 import scala.util.Failure
 
-trait FunFixtures { self: FunSuite =>
+trait FunFixtures { self: BaseFunSuite =>
 
   class FunFixture[T] private (
       val setup: TestOptions => Future[T],

--- a/munit/shared/src/main/scala/munit/FunSuite.scala
+++ b/munit/shared/src/main/scala/munit/FunSuite.scala
@@ -8,7 +8,9 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 import java.util.concurrent.TimeUnit
 
-abstract class FunSuite
+abstract class FunSuite extends BaseFunSuite
+
+trait BaseFunSuite
     extends Suite
     with Assertions
     with FunFixtures

--- a/munit/shared/src/main/scala/munit/SuiteTransforms.scala
+++ b/munit/shared/src/main/scala/munit/SuiteTransforms.scala
@@ -3,7 +3,7 @@ package munit
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-trait SuiteTransforms { this: FunSuite =>
+trait SuiteTransforms { this: BaseFunSuite =>
 
   final class SuiteTransform(val name: String, fn: List[Test] => List[Test])
       extends Function1[List[Test], List[Test]] {

--- a/munit/shared/src/main/scala/munit/TestTransforms.scala
+++ b/munit/shared/src/main/scala/munit/TestTransforms.scala
@@ -6,7 +6,7 @@ import scala.util.Failure
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-trait TestTransforms { this: FunSuite =>
+trait TestTransforms { this: BaseFunSuite =>
 
   final class TestTransform(val name: String, fn: Test => Test)
       extends Function1[Test, Test] {

--- a/munit/shared/src/main/scala/munit/ValueTransforms.scala
+++ b/munit/shared/src/main/scala/munit/ValueTransforms.scala
@@ -5,7 +5,7 @@ import munit.internal.FutureCompat._
 import scala.util.Try
 import munit.internal.console.StackTraces
 
-trait ValueTransforms { this: FunSuite =>
+trait ValueTransforms { this: BaseFunSuite =>
 
   final class ValueTransform(
       val name: String,


### PR DESCRIPTION
Fixes #288. This change allows test suites to extend another class while
bringing in all the functionality of `FunSuite`.