### PR TITLE
Respect `munitTimeout` for non-Future tests

### DIFF
--- a/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
@@ -20,11 +20,11 @@ object PlatformCompat {
     Future.successful(())
   }
   def waitAtMost[T](
-      future: Future[T],
+      startFuture: () => Future[T],
       duration: Duration,
       ec: ExecutionContext
   ): Future[T] = {
-    future
+    startFuture()
   }
 
   // Scala Native does not support looking up annotations at runtime.

--- a/munit/shared/src/main/scala/munit/FunSuite.scala
+++ b/munit/shared/src/main/scala/munit/FunSuite.scala
@@ -34,7 +34,7 @@ trait BaseFunSuite
         options.name,
         { () =>
           try {
-            waitForCompletion(munitValueTransform(body))
+            waitForCompletion(() => munitValueTransform(body))
           } catch {
             case NonFatal(e) =>
               Future.failed(e)
@@ -47,7 +47,7 @@ trait BaseFunSuite
   }
 
   def munitTimeout: Duration = new FiniteDuration(30, TimeUnit.SECONDS)
-  private final def waitForCompletion[T](f: Future[T]) =
+  private final def waitForCompletion[T](f: () => Future[T]) =
     PlatformCompat.waitAtMost(f, munitTimeout, munitExecutionContext)
 
 }

--- a/tests/js/src/test/scala/munit/TimeoutSuite.scala
+++ b/tests/js/src/test/scala/munit/TimeoutSuite.scala
@@ -1,0 +1,28 @@
+package munit
+
+import scala.scalajs.js.timers._
+import scala.concurrent.Promise
+import scala.concurrent.duration.Duration
+
+class TimeoutSuite extends BaseSuite {
+  override def munitTimeout: Duration = Duration(3, "ms")
+  test("setTimeout-exceeds".fail) {
+    val promise = Promise[Unit]()
+    setTimeout(1000) {
+      promise.success(())
+    }
+    promise.future
+  }
+  test("setTimeout-passes") {
+    val promise = Promise[Unit]()
+    setTimeout(1) {
+      promise.success(())
+    }
+    promise.future
+  }
+
+  // We can't use an infinite loop because it blocks the main thread preventing the test from completing.
+  //   test("infinite-loop".fail) {
+  //     ThrottleCpu.run()
+  //   }
+}

--- a/tests/jvm/src/main/scala/munit/ThrottleCpu.scala
+++ b/tests/jvm/src/main/scala/munit/ThrottleCpu.scala
@@ -1,0 +1,18 @@
+package munit
+
+object ThrottleCpu {
+  def run(): Unit = {
+    while (true) {
+      // Some computationally intensive calculation
+      1.to(1000).foreach(i => fib(i))
+      println("Loop")
+    }
+  }
+
+  private final def fib(n: Int): Int = {
+    if (n < 1) 0
+    else if (n == 1) n
+    else fib(n - 1) + fib(n - 2)
+  }
+
+}

--- a/tests/jvm/src/test/scala/munit/TimeoutSuite.scala
+++ b/tests/jvm/src/test/scala/munit/TimeoutSuite.scala
@@ -26,19 +26,21 @@ class TimeoutSuite extends munit.FunSuite {
   }
   test("infinite-loop".fail) {
     Future {
-      while (true) {
-        def fib(n: Int): Int = {
-          if (n < 1) 0
-          else if (n == 1) n
-          else fib(n - 1) + fib(n - 2)
-        }
-        // Some computationally intensive calculation
-        1.to(1000).foreach(i => fib(i))
-        println("Loop")
-      }
+      ThrottleCpu.run()
     }
   }
   test("fast-3") {
+    Future {
+      Thread.sleep(1)
+    }
+  }
+  test("slow-non-future".fail) {
+    ThrottleCpu.run()
+  }
+  test("slow-non-future-sleep".fail) {
+    Thread.sleep(1000)
+  }
+  test("fast-4") {
     Future {
       Thread.sleep(1)
     }


### PR DESCRIPTION
Fixes https://github.com/scalameta/munit/issues/292

Previously, the `munitTimeout` value was only used for async tests. Now,
  this value is respected for non-async tests as well.