### PR TITLE
Remove Scala.js-specific instructions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,28 +47,6 @@ object test extends Tests {
 }
 ```
 
-### Scala.js setup
-
-Additionally, if you are using Scala.js you will need to export your tests as
-CommonJS modules:
-
-**sbt:**
-
-```scala
-// The use of "Test / " allows the rest of your project to use a different module kind
-Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
-```
-
-**Mill**
-
-```scala
-object test extends Tests {
-  ...
-
-  override def moduleKind = T(mill.scalajslib.api.ModuleKind.CommonJSModule)
-}
-```
-
 | Scala Version | JVM | Scala.js (0.6.x) | Scala.js (1.x) | Native (0.4.x) |
 | ------------- | :-: | :--------------: | :------------: | :------------: |
 | 2.11.x        | ✅  | ✅ until 0.7.16  |       ✅       |       ✅       |


### PR DESCRIPTION
I can confirm this is no longer necessary as of #376.

Following up on #431.