### PR TITLE
Enable google-java-format for Java files

### DIFF
--- a/junit-interface/src/main/java/munit/internal/junitinterface/AbstractEvent.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/AbstractEvent.java
@@ -4,8 +4,7 @@ import sbt.testing.*;
 
 import static munit.internal.junitinterface.Ansi.*;
 
-abstract class AbstractEvent implements Event
-{
+abstract class AbstractEvent implements Event {
   protected final String ansiName;
   protected final String ansiMsg;
   protected final Status status;
@@ -13,8 +12,13 @@ abstract class AbstractEvent implements Event
   private final Fingerprint fingerprint;
   private final Long duration;
 
-  AbstractEvent(String ansiName, String ansiMsg, Status status, Fingerprint fingerprint, Long duration, Throwable error)
-  {
+  AbstractEvent(
+      String ansiName,
+      String ansiMsg,
+      Status status,
+      Fingerprint fingerprint,
+      Long duration,
+      Throwable error) {
     this.fingerprint = fingerprint;
     this.ansiName = ansiName;
     this.ansiMsg = ansiMsg;
@@ -47,7 +51,7 @@ abstract class AbstractEvent implements Event
 
   @Override
   public OptionalThrowable throwable() {
-    if( error == null ) {
+    if (error == null) {
       return new OptionalThrowable();
     } else {
       return new OptionalThrowable(error);

--- a/junit-interface/src/main/java/munit/internal/junitinterface/Ansi.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/Ansi.java
@@ -22,25 +22,22 @@ public class Ansi {
   private static final String LIGHT_MAGENTA = "\u001B[95m";
   private static final String LIGHT_CYAN = "\u001B[96m";
 
-  public static String c(String s, String colorSequence)
-  {
-    if(colorSequence == null) return s;
+  public static String c(String s, String colorSequence) {
+    if (colorSequence == null) return s;
     else return colorSequence + s + NORMAL;
   }
 
-  public static String filterAnsi(String s)
-  {
-    if(s == null) return null;
+  public static String filterAnsi(String s) {
+    if (s == null) return null;
     int len = s.length();
     StringBuilder b = new StringBuilder(len);
-    for(int i=0; i<len; i++)
-    {
+    for (int i = 0; i < len; i++) {
       char c = s.charAt(i);
-      if(c == '\u001B')
-      {
-        do { i++; } while(s.charAt(i) != 'm');
-      }
-      else b.append(c);
+      if (c == '\u001B') {
+        do {
+          i++;
+        } while (s.charAt(i) != 'm');
+      } else b.append(c);
     }
     return b.toString();
   }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/Configurable.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/Configurable.java
@@ -1,5 +1,5 @@
 package munit.internal.junitinterface;
 
 public interface Configurable {
-    public void configure(Settings settings);
+  public void configure(Settings settings);
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/CustomFingerprint.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/CustomFingerprint.java
@@ -38,8 +38,6 @@ public class CustomFingerprint implements SubclassFingerprint {
 
   @Override
   public String toString() {
-    return "CustomFingerprint{" +
-        "suite='" + suite + '\'' +
-        '}';
+    return "CustomFingerprint{" + "suite='" + suite + '\'' + '}';
   }
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/CustomRunners.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/CustomRunners.java
@@ -19,14 +19,15 @@ public class CustomRunners {
     this.superclasses = new HashSet<>();
     runners.forEach(runner -> this.superclasses.add(runner.suite));
   }
+
   public boolean isEmpty() {
     return runners.isEmpty();
   }
 
   public Map<String, String> all() {
-      Map<String, String> result = new HashMap<>();
-      runners.forEach(runner -> result.put(runner.suite, runner.runner));
-      return result;
+    Map<String, String> result = new HashMap<>();
+    runners.forEach(runner -> result.put(runner.suite, runner.runner));
+    return result;
   }
 
   public boolean matchesFingerprint(Fingerprint fingerprint) {

--- a/junit-interface/src/main/java/munit/internal/junitinterface/CustomSuperclasses.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/CustomSuperclasses.java
@@ -1,6 +1,5 @@
 package munit.internal.junitinterface;
 
-
 import java.util.Set;
 import sbt.testing.Fingerprint;
 import sbt.testing.SubclassFingerprint;

--- a/junit-interface/src/main/java/munit/internal/junitinterface/EmptyRunner.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/EmptyRunner.java
@@ -8,10 +8,14 @@ class EmptyRunner extends Runner {
 
   private final Description desc;
 
-  EmptyRunner(Description desc) { this.desc = desc; } 
+  EmptyRunner(Description desc) {
+    this.desc = desc;
+  }
 
   @Override
-  public Description getDescription() { return desc; }
+  public Description getDescription() {
+    return desc;
+  }
 
   @Override
   public void run(RunNotifier notifier) {}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
@@ -16,11 +16,10 @@ import sbt.testing.Status;
 
 import static munit.internal.junitinterface.Ansi.*;
 
-
-final class EventDispatcher extends RunListener
-{
+final class EventDispatcher extends RunListener {
   private final RichLogger logger;
-  private final Set<Description> reported = Collections.newSetFromMap(new ConcurrentHashMap<Description, Boolean>());
+  private final Set<Description> reported =
+      Collections.newSetFromMap(new ConcurrentHashMap<Description, Boolean>());
   private final AtomicBoolean suiteStartReported = new AtomicBoolean(false);
   private final ConcurrentHashMap<String, Long> startTimes = new ConcurrentHashMap<String, Long>();
   private final EventHandler handler;
@@ -29,9 +28,13 @@ final class EventDispatcher extends RunListener
   private final String taskInfo;
   private final RunStatistics runStatistics;
 
-  EventDispatcher(RichLogger logger, EventHandler handler, RunSettings settings, Fingerprint fingerprint,
-                  Description taskDescription, RunStatistics runStatistics)
-  {
+  EventDispatcher(
+      RichLogger logger,
+      EventHandler handler,
+      RunSettings settings,
+      Fingerprint fingerprint,
+      Description taskDescription,
+      RunStatistics runStatistics) {
     this.logger = logger;
     this.handler = handler;
     this.settings = settings;
@@ -44,16 +47,20 @@ final class EventDispatcher extends RunListener
     Event(String name, String message, Status status, Long duration, Throwable error) {
       super(name, message, status, fingerprint, duration, error);
     }
-    String durationSuffix() { return " " + durationToString(); }
+
+    String durationSuffix() {
+      return " " + durationToString();
+    }
   }
 
   private abstract class ErrorEvent extends Event {
     ErrorEvent(Failure failure, Status status) {
-      super(settings.buildErrorName(failure.getDescription(), status),
-            settings.buildErrorMessage(failure.getException()),
-            status,
-            elapsedTime(failure.getDescription()),
-            failure.getException());
+      super(
+          settings.buildErrorName(failure.getDescription(), status),
+          settings.buildErrorMessage(failure.getException()),
+          status,
+          elapsedTime(failure.getDescription()),
+          failure.getException());
     }
   }
 
@@ -64,72 +71,85 @@ final class EventDispatcher extends RunListener
   }
 
   @Override
-  public void testAssumptionFailure(final Failure failure)
-  {
-    postIfFirst(failure.getDescription(), new ErrorEvent(failure, Status.Skipped) {
-      void logTo(RichLogger logger) {
-        if (settings.verbose) {
-          logger.info(Ansi.c("==> i "  + failure.getDescription().getMethodName(), WARNMSG));
-        }
-      }
-    });
+  public void testAssumptionFailure(final Failure failure) {
+    postIfFirst(
+        failure.getDescription(),
+        new ErrorEvent(failure, Status.Skipped) {
+          void logTo(RichLogger logger) {
+            if (settings.verbose) {
+              logger.info(Ansi.c("==> i " + failure.getDescription().getMethodName(), WARNMSG));
+            }
+          }
+        });
   }
 
   @Override
-  public void testFailure(final Failure failure)
-  {
+  public void testFailure(final Failure failure) {
     if (failure.getDescription() != null && failure.getDescription().getClassName() != null) {
       try {
         trimStackTrace(
             failure.getException(),
             "java.lang.Thread",
             failure.getDescription().getClassName(),
-            settings
-        );
+            settings);
       } catch (Throwable t) {
         // Ignore error.
       }
     }
-    postIfFirst(failure.getDescription(), new ErrorEvent(failure, Status.Failure) {
-      void logTo(RichLogger logger) {
-        logger.error(settings.buildTestResult(Status.Failure) +ansiName+" "+ durationSuffix() + " " + ansiMsg, error);
-      }
-    });
-  }
-
-
-  @Override
-  public void testFinished(Description desc)
-  {
-    postIfFirst(desc, new InfoEvent(desc, Status.Success) {
-      void logTo(RichLogger logger) {
-        logger.info(settings.buildTestResult(Status.Success) + Ansi.c(desc.getMethodName(), SUCCESS1) + durationSuffix());
-      }
-    });
+    postIfFirst(
+        failure.getDescription(),
+        new ErrorEvent(failure, Status.Failure) {
+          void logTo(RichLogger logger) {
+            logger.error(
+                settings.buildTestResult(Status.Failure)
+                    + ansiName
+                    + " "
+                    + durationSuffix()
+                    + " "
+                    + ansiMsg,
+                error);
+          }
+        });
   }
 
   @Override
-  public void testIgnored(Description desc)
-  {
-    postIfFirst(desc, new InfoEvent(desc, Status.Skipped) {
-      void logTo(RichLogger logger) {
-        logger.warn(settings.buildTestResult(Status.Ignored) + ansiName+" ignored" + durationSuffix());
-      }
-    });
+  public void testFinished(Description desc) {
+    postIfFirst(
+        desc,
+        new InfoEvent(desc, Status.Success) {
+          void logTo(RichLogger logger) {
+            logger.info(
+                settings.buildTestResult(Status.Success)
+                    + Ansi.c(desc.getMethodName(), SUCCESS1)
+                    + durationSuffix());
+          }
+        });
   }
 
+  @Override
+  public void testIgnored(Description desc) {
+    postIfFirst(
+        desc,
+        new InfoEvent(desc, Status.Skipped) {
+          void logTo(RichLogger logger) {
+            logger.warn(
+                settings.buildTestResult(Status.Ignored)
+                    + ansiName
+                    + " ignored"
+                    + durationSuffix());
+          }
+        });
+  }
 
   @Override
-  public void testSuiteStarted(Description desc)
-  {
+  public void testSuiteStarted(Description desc) {
     if (desc == null || desc.getClassName() == null || desc.getClassName().equals("null")) return;
-    if (suiteStartReported.compareAndSet(false, true)) logger.info(c(desc.getClassName() + ":", SUCCESS1));
+    if (suiteStartReported.compareAndSet(false, true))
+      logger.info(c(desc.getClassName() + ":", SUCCESS1));
   }
 
-
   @Override
-  public void testStarted(Description desc)
-  {
+  public void testStarted(Description desc) {
     recordStartTime(desc);
     testSuiteStarted(desc);
     if (settings.verbose) {
@@ -143,7 +163,7 @@ final class EventDispatcher extends RunListener
 
   private Long elapsedTime(Description description) {
     Long startTime = startTimes.get(description.getMethodName());
-    if( startTime == null ) {
+    if (startTime == null) {
       return 0l;
     } else {
       return System.currentTimeMillis() - startTime;
@@ -151,15 +171,23 @@ final class EventDispatcher extends RunListener
   }
 
   @Override
-  public void testRunFinished(Result result)
-  {
-      if (settings.verbose) {
-        logger.info("Test run " +taskInfo+" finished: "+
-          result.getFailureCount()+" failed" +
-          ", " +
-          result.getIgnoreCount()+" ignored" +
-          ", "+result.getRunCount()+" total, "+(result.getRunTime()/1000.0)+"s") ;
-      }
+  public void testRunFinished(Result result) {
+    if (settings.verbose) {
+      logger.info(
+          "Test run "
+              + taskInfo
+              + " finished: "
+              + result.getFailureCount()
+              + " failed"
+              + ", "
+              + result.getIgnoreCount()
+              + " ignored"
+              + ", "
+              + result.getRunCount()
+              + " total, "
+              + (result.getRunTime() / 1000.0)
+              + "s");
+    }
     runStatistics.addTime(result.getRunTime());
   }
 
@@ -169,42 +197,39 @@ final class EventDispatcher extends RunListener
   }
 
   @Override
-  public void testRunStarted(Description desc)
-  {
-      if (settings.verbose) {
-        logger.info(taskInfo + " started");
-      }
+  public void testRunStarted(Description desc) {
+    if (settings.verbose) {
+      logger.info(taskInfo + " started");
+    }
   }
 
-  void testExecutionFailed(String testName, Throwable err)
-  {
-    post(new Event(Ansi.c(testName, Ansi.ERRMSG), settings.buildErrorMessage(err), Status.Error, 0L, err) {
-      void logTo(RichLogger logger) {
-        logger.error(ansiName+" failed: "+ansiMsg, error);
-      }
-    });
+  void testExecutionFailed(String testName, Throwable err) {
+    post(
+        new Event(
+            Ansi.c(testName, Ansi.ERRMSG), settings.buildErrorMessage(err), Status.Error, 0L, err) {
+          void logTo(RichLogger logger) {
+            logger.error(ansiName + " failed: " + ansiMsg, error);
+          }
+        });
   }
 
-
-  private void postIfFirst(Description desc, AbstractEvent e)
-  {
-    if(reported.add(desc)) {
+  private void postIfFirst(Description desc, AbstractEvent e) {
+    if (reported.add(desc)) {
       e.logTo(logger);
       runStatistics.captureStats(e);
       handler.handle(e);
     }
   }
 
-  void post(AbstractEvent e)
-  {
+  void post(AbstractEvent e) {
     e.logTo(logger);
     runStatistics.captureStats(e);
     handler.handle(e);
   }
 
-
   // Removes stack trace elements that reference the reflective invocation in TestLauncher.
-  private static void trimStackTrace(Throwable ex, String fromClassName, String toClassName, Settings settings) {
+  private static void trimStackTrace(
+      Throwable ex, String fromClassName, String toClassName, Settings settings) {
     if (!settings.trimStackTraces()) return;
     Throwable cause = ex;
     while (cause != null) {

--- a/junit-interface/src/main/java/munit/internal/junitinterface/GlobFilter.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/GlobFilter.java
@@ -6,15 +6,13 @@ import java.util.regex.Pattern;
 import org.junit.runner.Description;
 import org.junit.runner.manipulation.Filter;
 
-public final class GlobFilter extends Filter
-{
+public final class GlobFilter extends Filter {
   private final ArrayList<Pattern> patterns = new ArrayList<Pattern>();
   private final RunSettings settings;
 
-  public GlobFilter(RunSettings settings, Iterable<String> globPatterns)
-  {
+  public GlobFilter(RunSettings settings, Iterable<String> globPatterns) {
     this.settings = settings;
-    for(String p : globPatterns) patterns.add(compileGlobPattern(p));
+    for (String p : globPatterns) patterns.add(compileGlobPattern(p));
   }
 
   @Override
@@ -23,13 +21,11 @@ public final class GlobFilter extends Filter
   }
 
   @Override
-  public boolean shouldRun(Description d)
-  {
-    if(d.isSuite()) return true;
+  public boolean shouldRun(Description d) {
+    if (d.isSuite()) return true;
     String plainName = settings.buildPlainName(d);
 
-    for(Pattern p : patterns)
-      if(p.matcher(plainName).matches()) return true;
+    for (Pattern p : patterns) if (p.matcher(plainName).matches()) return true;
 
     return false;
   }
@@ -37,10 +33,9 @@ public final class GlobFilter extends Filter
   private static Pattern compileGlobPattern(String expr) {
     String[] a = expr.split("\\*", -1);
     StringBuilder b = new StringBuilder();
-    for(int i=0; i<a.length; i++) {
-      if(i != 0) b.append(".*");
-      if(!a[i].isEmpty())
-        b.append(Pattern.quote(a[i].replaceAll("\n", "\\n")));
+    for (int i = 0; i < a.length; i++) {
+      if (i != 0) b.append(".*");
+      if (!a[i].isEmpty()) b.append(Pattern.quote(a[i].replaceAll("\n", "\\n")));
     }
     return Pattern.compile(b.toString());
   }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnit3Fingerprint.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnit3Fingerprint.java
@@ -2,15 +2,19 @@ package munit.internal.junitinterface;
 
 import sbt.testing.SubclassFingerprint;
 
-
-public class JUnit3Fingerprint implements SubclassFingerprint
-{
+public class JUnit3Fingerprint implements SubclassFingerprint {
   @Override
-  public String superclassName() { return "junit.framework.TestCase"; }
-
-  @Override
-  public boolean isModule() { return false; }
+  public String superclassName() {
+    return "junit.framework.TestCase";
+  }
 
   @Override
-  public boolean requireNoArgConstructor() { return false; }
+  public boolean isModule() {
+    return false;
+  }
+
+  @Override
+  public boolean requireNoArgConstructor() {
+    return false;
+  }
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitComputer.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitComputer.java
@@ -21,20 +21,22 @@ public class JUnitComputer extends Computer {
   final Map<Class<?>, Class<?>> suiteRunners;
   final Settings settings;
 
-  public JUnitComputer(ClassLoader testClassLoader, CustomRunners customRunners, Settings settings) {
+  public JUnitComputer(
+      ClassLoader testClassLoader, CustomRunners customRunners, Settings settings) {
     this.settings = settings;
     suiteRunners = new HashMap<>();
-      customRunners.all().forEach((suite, runner) -> {
-        try {
-          suiteRunners.put(
-              testClassLoader.loadClass(suite),
-              testClassLoader.loadClass(runner)
-          );
-        } catch (ClassNotFoundException e) {
-          // ignore, since we'll fail to find at least one of the 2 `JUnitRunners`
-          // (it moved from `org.scalatest.junit` to `org.scalatestplus.junit` in 3.1)
-        }
-      });
+    customRunners
+        .all()
+        .forEach(
+            (suite, runner) -> {
+              try {
+                suiteRunners.put(
+                    testClassLoader.loadClass(suite), testClassLoader.loadClass(runner));
+              } catch (ClassNotFoundException e) {
+                // ignore, since we'll fail to find at least one of the 2 `JUnitRunners`
+                // (it moved from `org.scalatest.junit` to `org.scalatestplus.junit` in 3.1)
+              }
+            });
   }
 
   public Optional<Class<?>> customRunner(Class<?> clazz) {
@@ -45,7 +47,6 @@ public class JUnitComputer extends Computer {
     }
     return Optional.empty();
   }
-
 
   private class MySuite extends Suite implements Filterable {
     public MySuite(RunnerBuilder runnerBuilder, Class<?>[] classes) throws InitializationError {
@@ -62,12 +63,13 @@ public class JUnitComputer extends Computer {
 
   @Override
   public Runner getSuite(RunnerBuilder builder, Class<?>[] classes) throws InitializationError {
-    RunnerBuilder runnerBuilder = new RunnerBuilder() {
-      @Override
-      public Runner runnerForClass(Class<?> testClass) throws Throwable {
-        return getRunner(builder, testClass);
-      }
-    };
+    RunnerBuilder runnerBuilder =
+        new RunnerBuilder() {
+          @Override
+          public Runner runnerForClass(Class<?> testClass) throws Throwable {
+            return getRunner(builder, testClass);
+          }
+        };
     return new MySuite(runnerBuilder, classes);
   }
 

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitFingerprint.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitFingerprint.java
@@ -2,8 +2,12 @@ package munit.internal.junitinterface;
 
 public class JUnitFingerprint extends AbstractAnnotatedFingerprint {
   @Override
-  public String annotationName() { return "org.junit.Test"; }
+  public String annotationName() {
+    return "org.junit.Test";
+  }
 
   @Override
-  public boolean isModule() { return false; }
+  public boolean isModule() {
+    return false;
+  }
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitFramework.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitFramework.java
@@ -5,17 +5,14 @@ import java.util.Arrays;
 import sbt.testing.Fingerprint;
 import sbt.testing.Framework;
 
-
-public class JUnitFramework implements Framework
-{
-  private static Fingerprint[] FINGERPRINTS = new Fingerprint[] {
-      new RunWithFingerprint(),
-      new JUnitFingerprint(),
-      new JUnit3Fingerprint()
-  };
+public class JUnitFramework implements Framework {
+  private static Fingerprint[] FINGERPRINTS =
+      new Fingerprint[] {new RunWithFingerprint(), new JUnitFingerprint(), new JUnit3Fingerprint()};
 
   @Override
-  public String name() { return "JUnit"; }
+  public String name() {
+    return "JUnit";
+  }
 
   @Override
   public sbt.testing.Fingerprint[] fingerprints() {
@@ -23,7 +20,8 @@ public class JUnitFramework implements Framework
     if (customRunners.isEmpty()) return FINGERPRINTS;
     Fingerprint[] result = new Fingerprint[FINGERPRINTS.length + customRunners.runners.size()];
     System.arraycopy(FINGERPRINTS, 0, result, 0, FINGERPRINTS.length);
-    CustomFingerprint[] customFingerprints = customRunners.runners.toArray(new CustomFingerprint[0]);
+    CustomFingerprint[] customFingerprints =
+        customRunners.runners.toArray(new CustomFingerprint[0]);
     System.arraycopy(customFingerprints, 0, result, FINGERPRINTS.length, customFingerprints.length);
     return result;
   }
@@ -33,7 +31,8 @@ public class JUnitFramework implements Framework
   }
 
   @Override
-  public sbt.testing.Runner runner(String[] args, String[] remoteArgs, ClassLoader testClassLoader) {
+  public sbt.testing.Runner runner(
+      String[] args, String[] remoteArgs, ClassLoader testClassLoader) {
     return new JUnitRunner(args, remoteArgs, testClassLoader, customRunners());
   }
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitRunner.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitRunner.java
@@ -13,7 +13,6 @@ import sbt.testing.Runner;
 import sbt.testing.Task;
 import sbt.testing.TaskDef;
 
-
 final class JUnitRunner implements Runner {
   private final String[] args;
   private final String[] remoteArgs;
@@ -26,7 +25,11 @@ final class JUnitRunner implements Runner {
   final RunStatistics runStatistics;
   final CustomRunners customRunners;
 
-  JUnitRunner(String[] args, String[] remoteArgs, ClassLoader testClassLoader, CustomRunners customRunners) {
+  JUnitRunner(
+      String[] args,
+      String[] remoteArgs,
+      ClassLoader testClassLoader,
+      CustomRunners customRunners) {
 
     this.args = args;
     this.remoteArgs = remoteArgs;
@@ -34,8 +37,12 @@ final class JUnitRunner implements Runner {
     this.customRunners = customRunners;
     Settings defaults = Settings.defaults();
 
-    boolean nocolor = false, decodeScalaNames = false,
-        logAssert = true, logExceptionClass = true, useSbtLoggers = false, useBufferedLoggers = true;
+    boolean nocolor = false,
+        decodeScalaNames = false,
+        logAssert = true,
+        logExceptionClass = true,
+        useSbtLoggers = false,
+        useBufferedLoggers = true;
     boolean verbose = false;
     boolean trimStackTraces = defaults.trimStackTraces();
     RunSettings.Summary summary = RunSettings.Summary.SBT;
@@ -49,45 +56,64 @@ final class JUnitRunner implements Runner {
     String testFilter = "";
     String ignoreRunners = "org.junit.runners.Suite";
     String runListener = null;
-    for(String s : args) {
-      if("-v".equals(s) || "--verbose".equals(s)) verbose = true;
-      else if(s.startsWith("--summary=")) summary = RunSettings.Summary.values()[Integer.parseInt(s.substring(10))];
-      else if("-n".equals(s)) nocolor = true;
-      else if("-s".equals(s)) decodeScalaNames = true;
-      else if("-a".equals(s)) logAssert = true;
-      else if("-c".equals(s)) logExceptionClass = false;
-      else if("+l".equals(s)) useSbtLoggers = true;
-      else if("+b".equals(s)) useBufferedLoggers = true;
-      else if("-b".equals(s)) useBufferedLoggers = false;
-      else if("--logger=sbt".equals(s)) useSbtLoggers = true;
-      else if("--logger=buffered".equals(s)) useBufferedLoggers = true;
-      else if("-l".equals(s)) useSbtLoggers = false;
-      else if("-F".equals(s)) trimStackTraces = false;
-      else if("+F".equals(s)) trimStackTraces = true;
-      else if(s.startsWith("--tests=")) testFilter = s.substring(8);
-      else if(s.startsWith("--ignore-runners=")) ignoreRunners = s.substring(17);
-      else if(s.startsWith("--run-listener=")) runListener = s.substring(15);
-      else if(s.startsWith("--include-categories=")) includeCategories.addAll(Arrays.asList(s.substring(21).split(",")));
-      else if(s.startsWith("--exclude-categories=")) excludeCategories.addAll(Arrays.asList(s.substring(21).split(",")));
-      else if(s.startsWith("--include-tags=")) includeTags.addAll(Arrays.asList(s.substring("--include-tags=".length()).split(",")));
-      else if(s.startsWith("--exclude-tags=")) excludeTags.addAll(Arrays.asList(s.substring("--exclude-tags=".length()).split(",")));
-      else if(s.startsWith("-D") && s.contains("=")) {
+    for (String s : args) {
+      if ("-v".equals(s) || "--verbose".equals(s)) verbose = true;
+      else if (s.startsWith("--summary="))
+        summary = RunSettings.Summary.values()[Integer.parseInt(s.substring(10))];
+      else if ("-n".equals(s)) nocolor = true;
+      else if ("-s".equals(s)) decodeScalaNames = true;
+      else if ("-a".equals(s)) logAssert = true;
+      else if ("-c".equals(s)) logExceptionClass = false;
+      else if ("+l".equals(s)) useSbtLoggers = true;
+      else if ("+b".equals(s)) useBufferedLoggers = true;
+      else if ("-b".equals(s)) useBufferedLoggers = false;
+      else if ("--logger=sbt".equals(s)) useSbtLoggers = true;
+      else if ("--logger=buffered".equals(s)) useBufferedLoggers = true;
+      else if ("-l".equals(s)) useSbtLoggers = false;
+      else if ("-F".equals(s)) trimStackTraces = false;
+      else if ("+F".equals(s)) trimStackTraces = true;
+      else if (s.startsWith("--tests=")) testFilter = s.substring(8);
+      else if (s.startsWith("--ignore-runners=")) ignoreRunners = s.substring(17);
+      else if (s.startsWith("--run-listener=")) runListener = s.substring(15);
+      else if (s.startsWith("--include-categories="))
+        includeCategories.addAll(Arrays.asList(s.substring(21).split(",")));
+      else if (s.startsWith("--exclude-categories="))
+        excludeCategories.addAll(Arrays.asList(s.substring(21).split(",")));
+      else if (s.startsWith("--include-tags="))
+        includeTags.addAll(Arrays.asList(s.substring("--include-tags=".length()).split(",")));
+      else if (s.startsWith("--exclude-tags="))
+        excludeTags.addAll(Arrays.asList(s.substring("--exclude-tags=".length()).split(",")));
+      else if (s.startsWith("-D") && s.contains("=")) {
         int sep = s.indexOf('=');
-        sysprops.put(s.substring(2, sep), s.substring(sep+1));
-      }
-      else if(!s.startsWith("-") && !s.startsWith("+")) globPatterns.add(s);
+        sysprops.put(s.substring(2, sep), s.substring(sep + 1));
+      } else if (!s.startsWith("-") && !s.startsWith("+")) globPatterns.add(s);
     }
-    for(String s : args) {
-      if("+n".equals(s)) nocolor = false;
-      else if("+s".equals(s)) decodeScalaNames = false;
-      else if("+a".equals(s)) logAssert = false;
-      else if("+c".equals(s)) logExceptionClass = true;
-      else if("+l".equals(s)) useSbtLoggers = true;
+    for (String s : args) {
+      if ("+n".equals(s)) nocolor = false;
+      else if ("+s".equals(s)) decodeScalaNames = false;
+      else if ("+a".equals(s)) logAssert = false;
+      else if ("+c".equals(s)) logExceptionClass = true;
+      else if ("+l".equals(s)) useSbtLoggers = true;
     }
     this.settings =
-      new RunSettings(!nocolor, decodeScalaNames, verbose, useSbtLoggers, useBufferedLoggers, trimStackTraces, summary, logAssert, ignoreRunners, logExceptionClass,
-          sysprops, globPatterns, includeCategories, excludeCategories, includeTags, excludeTags,
-        testFilter);
+        new RunSettings(
+            !nocolor,
+            decodeScalaNames,
+            verbose,
+            useSbtLoggers,
+            useBufferedLoggers,
+            trimStackTraces,
+            summary,
+            logAssert,
+            ignoreRunners,
+            logExceptionClass,
+            sysprops,
+            globPatterns,
+            includeCategories,
+            excludeCategories,
+            includeTags,
+            excludeTags,
+            testFilter);
     this.runListener = createRunListener(runListener);
     this.runStatistics = new RunStatistics(settings);
   }
@@ -110,13 +136,15 @@ final class JUnitRunner implements Runner {
   private boolean shouldRun(JUnitComputer computer, TaskDef taskDef) {
     try {
       Class<?> cls = testClassLoader.loadClass(taskDef.fullyQualifiedName());
-      return !computer.customRunner(cls).isPresent() || customRunners.matchesFingerprint(taskDef.fingerprint());
+      return !computer.customRunner(cls).isPresent()
+          || customRunners.matchesFingerprint(taskDef.fingerprint());
     } catch (ClassNotFoundException e) {
       return false;
     }
   }
+
   private RunListener createRunListener(String runListenerClassName) {
-    if(runListenerClassName != null) {
+    if (runListenerClassName != null) {
       try {
         return (RunListener) testClassLoader.loadClass(runListenerClassName).newInstance();
       } catch (Exception e) {
@@ -128,9 +156,9 @@ final class JUnitRunner implements Runner {
   @Override
   public String done() {
     // Can't simply return the summary due to https://github.com/sbt/sbt/issues/3510
-    if(!used) return "";
+    if (!used) return "";
     String stats = runStatistics.createSummary();
-    if(stats.isEmpty()) return stats;
+    if (stats.isEmpty()) return stats;
     System.out.println(stats);
     return " ";
   }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitRunnerWrapper.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitRunnerWrapper.java
@@ -8,24 +8,24 @@ import org.junit.runner.manipulation.NoTestsRemainException;
 import org.junit.runner.notification.RunNotifier;
 
 class JUnitRunnerWrapper extends Runner implements Filterable {
-    private final Runner delegate;
+  private final Runner delegate;
 
-    JUnitRunnerWrapper(Runner delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override
-    public Description getDescription() {
-      return delegate.getDescription();
-    }
-
-    @Override
-    public void run(RunNotifier notifier) {
-      delegate.run(notifier);
-    }
-
-    @Override
-    public void filter(Filter filter) throws NoTestsRemainException {
-      filter.apply(delegate);
-    }
+  JUnitRunnerWrapper(Runner delegate) {
+    this.delegate = delegate;
   }
+
+  @Override
+  public Description getDescription() {
+    return delegate.getDescription();
+  }
+
+  @Override
+  public void run(RunNotifier notifier) {
+    delegate.run(notifier);
+  }
+
+  @Override
+  public void filter(Filter filter) throws NoTestsRemainException {
+    filter.apply(delegate);
+  }
+}

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitTask.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitTask.java
@@ -26,7 +26,8 @@ final class JUnitTask implements Task {
   private final TaskDef taskDef;
   private final JUnitComputer computer;
 
-  public JUnitTask(JUnitRunner runner, RunSettings settings, TaskDef taskDef, JUnitComputer computer) {
+  public JUnitTask(
+      JUnitRunner runner, RunSettings settings, TaskDef taskDef, JUnitComputer computer) {
     this.runner = runner;
     this.settings = settings;
     this.taskDef = taskDef;
@@ -35,11 +36,13 @@ final class JUnitTask implements Task {
 
   @Override
   public String[] tags() {
-    return new String[0];  // no tags yet
+    return new String[0]; // no tags yet
   }
 
   @Override
-  public TaskDef taskDef() { return taskDef; }
+  public TaskDef taskDef() {
+    return taskDef;
+  }
 
   @Override
   public Task[] execute(EventHandler eventHandler, Logger[] loggers) {
@@ -47,7 +50,9 @@ final class JUnitTask implements Task {
     String testClassName = taskDef.fullyQualifiedName();
     Description taskDescription = Description.createSuiteDescription(testClassName);
     RichLogger logger = new RichLogger(loggers, settings, testClassName, runner);
-    EventDispatcher ed = new EventDispatcher(logger, eventHandler, settings, fingerprint, taskDescription, runner.runStatistics);
+    EventDispatcher ed =
+        new EventDispatcher(
+            logger, eventHandler, settings, fingerprint, taskDescription, runner.runStatistics);
     JUnitCore ju = new JUnitCore();
     ju.addListener(ed);
     if (runner.runListener != null) ju.addListener(runner.runListener);
@@ -57,25 +62,33 @@ final class JUnitTask implements Task {
       try {
         Class<?> cl = runner.testClassLoader.loadClass(testClassName);
         boolean isRun = shouldRun(fingerprint, cl, settings);
-        if(isRun) {
+        if (isRun) {
           Request request = Request.classes(computer, cl);
-          if(settings.globPatterns.size() > 0) {
-            request = new SilentFilterRequest(request, new GlobFilter(settings, settings.globPatterns));
+          if (settings.globPatterns.size() > 0) {
+            request =
+                new SilentFilterRequest(request, new GlobFilter(settings, settings.globPatterns));
           }
-          if(settings.testFilter.length() > 0) {
+          if (settings.testFilter.length() > 0) {
             request = new SilentFilterRequest(request, new TestFilter(settings.testFilter, ed));
           }
-          if(!settings.includeCategories.isEmpty() || !settings.excludeCategories.isEmpty()) {
-            request = new SilentFilterRequest(request,
-                Categories.CategoryFilter.categoryFilter(true, loadClasses(runner.testClassLoader, settings.includeCategories), true,
-                    loadClasses(runner.testClassLoader, settings.excludeCategories)));
+          if (!settings.includeCategories.isEmpty() || !settings.excludeCategories.isEmpty()) {
+            request =
+                new SilentFilterRequest(
+                    request,
+                    Categories.CategoryFilter.categoryFilter(
+                        true,
+                        loadClasses(runner.testClassLoader, settings.includeCategories),
+                        true,
+                        loadClasses(runner.testClassLoader, settings.excludeCategories)));
           }
-          if(!settings.includeTags.isEmpty() || !settings.excludeTags.isEmpty()) {
-            request = new SilentFilterRequest(request, new TagFilter(settings.includeTags, settings.excludeTags));
+          if (!settings.includeTags.isEmpty() || !settings.excludeTags.isEmpty()) {
+            request =
+                new SilentFilterRequest(
+                    request, new TagFilter(settings.includeTags, settings.excludeTags));
           }
           ju.run(request);
         }
-      } catch(Exception ex) {
+      } catch (Exception ex) {
         ed.testExecutionFailed(testClassName, ex);
       }
     } finally {
@@ -85,29 +98,28 @@ final class JUnitTask implements Task {
     return new Task[0]; // junit tests do not nest
   }
 
-
   private boolean shouldRun(Fingerprint fingerprint, Class<?> clazz, RunSettings settings) {
-    if(JUNIT_FP.equals(fingerprint)) {
+    if (JUNIT_FP.equals(fingerprint)) {
       // Ignore classes which are matched by the other fingerprints
-      if(TestCase.class.isAssignableFrom(clazz)) {
+      if (TestCase.class.isAssignableFrom(clazz)) {
         return false;
       }
-      for(Annotation a : clazz.getDeclaredAnnotations()) {
-        if(a.annotationType().equals(RunWith.class)) return false;
+      for (Annotation a : clazz.getDeclaredAnnotations()) {
+        if (a.annotationType().equals(RunWith.class)) return false;
       }
       return true;
     } else {
       RunWith rw = clazz.getAnnotation(RunWith.class);
-      if(rw != null) {
+      if (rw != null) {
         return !settings.ignoreRunner(rw.value().getName());
-      }
-      else return true;
+      } else return true;
     }
   }
 
-  private static Set<Class<?>> loadClasses(ClassLoader classLoader, Set<String> classNames) throws ClassNotFoundException {
+  private static Set<Class<?>> loadClasses(ClassLoader classLoader, Set<String> classNames)
+      throws ClassNotFoundException {
     Set<Class<?>> classes = new HashSet<Class<?>>();
-    for(String className : classNames) {
+    for (String className : classNames) {
       classes.add(classLoader.loadClass(className));
     }
     return classes;

--- a/junit-interface/src/main/java/munit/internal/junitinterface/PantsFramework.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/PantsFramework.java
@@ -7,24 +7,21 @@ import sbt.testing.Fingerprint;
 
 public class PantsFramework extends JUnitFramework {
 
-  private static final CustomFingerprint scalatestFingerprint = CustomFingerprint.of(
-      "org.scalatest.Suite",
-      "org.scalatest.junit.JUnitRunner"
-  );
+  private static final CustomFingerprint scalatestFingerprint =
+      CustomFingerprint.of("org.scalatest.Suite", "org.scalatest.junit.JUnitRunner");
 
   // In ScalaTest 3.1+, `JUnitRunner` moved to a different package.
-  private static final CustomFingerprint scalatestPlusJunitFingerprint = CustomFingerprint.of(
-      "org.scalatest.Suite",
-      "org.scalatestplus.junit.JUnitRunner"
-  );
+  private static final CustomFingerprint scalatestPlusJunitFingerprint =
+      CustomFingerprint.of("org.scalatest.Suite", "org.scalatestplus.junit.JUnitRunner");
 
-  private static final Fingerprint[] FINGERPRINTS = new Fingerprint[] {
-      new RunWithFingerprint(),
-      new JUnitFingerprint(),
-      new JUnit3Fingerprint(),
-      scalatestFingerprint,
-      scalatestPlusJunitFingerprint
-  };
+  private static final Fingerprint[] FINGERPRINTS =
+      new Fingerprint[] {
+        new RunWithFingerprint(),
+        new JUnitFingerprint(),
+        new JUnit3Fingerprint(),
+        scalatestFingerprint,
+        scalatestPlusJunitFingerprint
+      };
 
   @Override
   public Fingerprint[] fingerprints() {
@@ -37,7 +34,8 @@ public class PantsFramework extends JUnitFramework {
   }
 
   @Override
-  public sbt.testing.Runner runner(String[] args, String[] remoteArgs, ClassLoader testClassLoader) {
+  public sbt.testing.Runner runner(
+      String[] args, String[] remoteArgs, ClassLoader testClassLoader) {
     String[] newArgs = new String[args.length + 1];
     // NOTE(olafur): by default, stderr is not printed when running tests. Users can still enable
     // stderr by passing in the "--stderr" flag.

--- a/junit-interface/src/main/java/munit/internal/junitinterface/RichLogger.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RichLogger.java
@@ -8,9 +8,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import sbt.testing.Logger;
 import static munit.internal.junitinterface.Ansi.*;
 
-
-final class RichLogger
-{
+final class RichLogger {
   private final Logger[] loggers;
   private final RunSettings settings;
   private final JUnitRunner runner;
@@ -18,16 +16,14 @@ final class RichLogger
   private final Map<String, Boolean> highlightedCache = new HashMap<>();
   private final ConcurrentLinkedDeque<String> buffer = new ConcurrentLinkedDeque<>();
 
-  RichLogger(Logger[] loggers, RunSettings settings, String testClassName, JUnitRunner runner)
-  {
+  RichLogger(Logger[] loggers, RunSettings settings, String testClassName, JUnitRunner runner) {
     this.loggers = loggers;
     this.settings = settings;
     this.runner = runner;
     this.testClassName = testClassName;
   }
 
-  void error(String s)
-  {
+  void error(String s) {
     if (settings.useSbtLoggers) {
       for (Logger l : loggers)
         if (settings.color && l.ansiCodesSupported()) l.error(s);
@@ -39,14 +35,12 @@ final class RichLogger
     }
   }
 
-  void error(String s, Throwable t)
-  {
+  void error(String s, Throwable t) {
     error(s);
-    if(t != null && (settings.logAssert || !(t instanceof AssertionError))) logStackTrace(t);
+    if (t != null && (settings.logAssert || !(t instanceof AssertionError))) logStackTrace(t);
   }
 
-  void info(String s)
-  {
+  void info(String s) {
     if (settings.useSbtLoggers) {
       for (Logger l : loggers)
         if (settings.color && l.ansiCodesSupported()) l.info(s);
@@ -58,8 +52,7 @@ final class RichLogger
     }
   }
 
-  void warn(String s)
-  {
+  void warn(String s) {
     if (settings.useSbtLoggers) {
       for (Logger l : loggers)
         if (settings.color && l.ansiCodesSupported()) l.warn(s);
@@ -81,74 +74,64 @@ final class RichLogger
   private void bufferMessage(String message) {
     buffer.addLast(message);
   }
-  private void logStackTrace(Throwable t)
-  {
+
+  private void logStackTrace(Throwable t) {
     StackTraceElement[] trace = t.getStackTrace();
     String testFileName = settings.color ? findTestFileName(trace, testClassName) : null;
-    logStackTracePart(trace, trace.length-1, 0, t, testFileName);
+    logStackTracePart(trace, trace.length - 1, 0, t, testFileName);
   }
 
-  private void logStackTracePart(StackTraceElement[] trace, int m, int framesInCommon, Throwable t, String testFileName)
-  {
+  private void logStackTracePart(
+      StackTraceElement[] trace, int m, int framesInCommon, Throwable t, String testFileName) {
     final int m0 = m;
     int top = 0;
-    for(int i=top; i<=m; i++)
-    {
-      if(trace[i].toString().startsWith("org.junit.") ||
-          trace[i].toString().startsWith("org.hamcrest.") ||
-          trace[i].toString().startsWith("org.scalatest."))
-      {
-        if(i == top) top++;
-        else
-        {
-          m = i-1;
-          while(m > top)
-          {
+    for (int i = top; i <= m; i++) {
+      if (trace[i].toString().startsWith("org.junit.")
+          || trace[i].toString().startsWith("org.hamcrest.")
+          || trace[i].toString().startsWith("org.scalatest.")) {
+        if (i == top) top++;
+        else {
+          m = i - 1;
+          while (m > top) {
             String s = trace[m].toString();
-            if(!s.startsWith("java.lang.reflect.") && !s.startsWith("sun.reflect.")) break;
+            if (!s.startsWith("java.lang.reflect.") && !s.startsWith("sun.reflect.")) break;
             m--;
           }
           break;
         }
       }
     }
-    for(int i=top; i<=m; i++) {
+    for (int i = top; i <= m; i++) {
       if (!trace[i].getClassName().startsWith("scala.runtime."))
         error(stackTraceElementToString(trace[i], testFileName));
     }
-    if(m0 != m)
-    {
+    if (m0 != m) {
       // skip junit-related frames
       error("    ...");
-    }
-    else if(framesInCommon != 0)
-    {
+    } else if (framesInCommon != 0) {
       // skip frames that were in the previous trace too
       error("    ... " + framesInCommon + " more");
     }
     logStackTraceAsCause(trace, t.getCause(), testFileName);
   }
 
-  private void logStackTraceAsCause(StackTraceElement[] causedTrace, Throwable t, String testFileName)
-  {
-    if(t == null) return;
+  private void logStackTraceAsCause(
+      StackTraceElement[] causedTrace, Throwable t, String testFileName) {
+    if (t == null) return;
     StackTraceElement[] trace = t.getStackTrace();
     int m = trace.length - 1, n = causedTrace.length - 1;
-    while(m >= 0 && n >= 0 && trace[m].equals(causedTrace[n]))
-    {
+    while (m >= 0 && n >= 0 && trace[m].equals(causedTrace[n])) {
       m--;
       n--;
     }
     error("Caused by: " + t);
-    logStackTracePart(trace, m, trace.length-1-m, t, testFileName);
+    logStackTracePart(trace, m, trace.length - 1 - m, t, testFileName);
   }
 
-  private String findTestFileName(StackTraceElement[] trace, String testClassName)
-  {
-    for(StackTraceElement e : trace)
-    {
+  private String findTestFileName(StackTraceElement[] trace, String testClassName) {
+    for (StackTraceElement e : trace) {
       String cln = e.getClassName();
-      if(testClassName.equals(cln)) return e.getFileName();
+      if (testClassName.equals(cln)) return e.getFileName();
     }
     return null;
   }
@@ -160,7 +143,7 @@ final class RichLogger
   private boolean isHighlighted(String className) {
     try {
       int dot = className.lastIndexOf('.');
-      String classfile = className.substring(0, dot + 1).replace('.','/');
+      String classfile = className.substring(0, dot + 1).replace('.', '/');
       URL resource = runner.testClassLoader.getResource(classfile);
       return resource.getProtocol().equals("file");
     } catch (Exception ex) {
@@ -168,28 +151,24 @@ final class RichLogger
     }
   }
 
-  private String stackTraceElementToString(StackTraceElement e, String testFileName)
-  {
-    boolean highlight = settings.color && (
-        testClassName.equals(e.getClassName()) ||
-        (testFileName != null && testFileName.equals(e.getFileName())) ||
-        isHighlightedCached(e.getClassName())
-      );
+  private String stackTraceElementToString(StackTraceElement e, String testFileName) {
+    boolean highlight =
+        settings.color
+            && (testClassName.equals(e.getClassName())
+                || (testFileName != null && testFileName.equals(e.getFileName()))
+                || isHighlightedCached(e.getClassName()));
     String color = highlight ? BOLD : FAINT;
     StringBuilder b = new StringBuilder();
     b.append(c("    at ", color));
-    b.append(c(settings.decodeName(e.getClassName() + '.' + e.getMethodName()) , color));
+    b.append(c(settings.decodeName(e.getClassName() + '.' + e.getMethodName()), color));
     b.append(c("(", color));
 
-    if(e.isNativeMethod()) b.append(c("Native Method", color));
-    else if(e.getFileName() == null) b.append(c("Unknown Source", color));
-    else
-    {
+    if (e.isNativeMethod()) b.append(c("Native Method", color));
+    else if (e.getFileName() == null) b.append(c("Unknown Source", color));
+    else {
       b.append(c(e.getFileName(), color));
-      if(e.getLineNumber() >= 0)
-        b.append(':').append(c(String.valueOf(e.getLineNumber()), color));
+      if (e.getLineNumber() >= 0) b.append(':').append(c(String.valueOf(e.getLineNumber()), color));
     }
     return b.append(c(")", color)).toString();
   }
-
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
@@ -41,15 +41,24 @@ class RunSettings implements Settings {
   private final HashMap<String, String> sysprops;
   private final HashSet<String> ignoreRunners = new HashSet<String>();
 
-  RunSettings(boolean color, boolean decodeScalaNames,
-              boolean verbose, boolean useSbtLoggers, boolean useBufferedLoggers, boolean trimStackTraces,
-              Summary summary, boolean logAssert, String ignoreRunners,
-              boolean logExceptionClass,
-              HashMap<String, String> sysprops,
-              ArrayList<String> globPatterns,
-              Set<String> includeCategories, Set<String> excludeCategories,
-              Set<String> includeTags, Set<String> excludeTags,
-              String testFilter) {
+  RunSettings(
+      boolean color,
+      boolean decodeScalaNames,
+      boolean verbose,
+      boolean useSbtLoggers,
+      boolean useBufferedLoggers,
+      boolean trimStackTraces,
+      Summary summary,
+      boolean logAssert,
+      String ignoreRunners,
+      boolean logExceptionClass,
+      HashMap<String, String> sysprops,
+      ArrayList<String> globPatterns,
+      Set<String> includeCategories,
+      Set<String> excludeCategories,
+      Set<String> includeTags,
+      Set<String> excludeTags,
+      String testFilter) {
     this.color = color;
     this.decodeScalaNames = decodeScalaNames;
     this.verbose = verbose;
@@ -58,8 +67,7 @@ class RunSettings implements Settings {
     this.logExceptionClass = logExceptionClass;
     this.includeTags = includeTags;
     this.excludeTags = excludeTags;
-    for(String s : ignoreRunners.split(","))
-      this.ignoreRunners.add(s.trim());
+    for (String s : ignoreRunners.split(",")) this.ignoreRunners.add(s.trim());
     this.sysprops = sysprops;
     this.globPatterns = globPatterns;
     this.includeCategories = includeCategories;
@@ -78,11 +86,11 @@ class RunSettings implements Settings {
     try {
       Class<?> cl = Class.forName("scala.reflect.NameTransformer");
       Method m = cl.getMethod("decode", String.class);
-      String decoded = (String)m.invoke(null, name);
+      String decoded = (String) m.invoke(null, name);
       return decoded == null ? name : decoded;
-    } catch(Throwable t) {
-      //System.err.println("Error decoding Scala name:");
-      //t.printStackTrace(System.err);
+    } catch (Throwable t) {
+      // System.err.println("Error decoding Scala name:");
+      // t.printStackTrace(System.err);
       return name;
     }
   }
@@ -133,20 +141,20 @@ class RunSettings implements Settings {
 
   String buildTestResult(Status status) {
     switch (status) {
-        case Success:
-          return c("  + ", SUCCESS1);
-        case Ignored:
-          return c("==> i ", SKIPPED);
-        case Skipped:
-          return c("==> s ", SKIPPED);
-        default:
-          return c("==> X ", ERRMSG);
-      }
+      case Success:
+        return c("  + ", SUCCESS1);
+      case Ignored:
+        return c("==> i ", SKIPPED);
+      case Skipped:
+        return c("==> s ", SKIPPED);
+      default:
+        return c("==> X ", ERRMSG);
+    }
   }
 
   String buildColoredMessage(Throwable t, String c1) {
-    if(t == null) return "null";
-    if(!logExceptionClass || (!logAssert && (t instanceof AssertionError)))  return t.getMessage();
+    if (t == null) return "null";
+    if (!logExceptionClass || (!logAssert && (t instanceof AssertionError))) return t.getMessage();
     StringBuilder b = new StringBuilder();
     b.append(decodeName(t.getClass().getName()));
     b.append(": ").append(t.getMessage());
@@ -162,23 +170,25 @@ class RunSettings implements Settings {
     String cn = decodeName(desc.getClassName());
     b.append(c(cn, c1));
     String m = desc.getMethodName();
-    if(m != null) {
+    if (m != null) {
       b.append('.');
       b.append(c(decodeName(m), c2));
     }
     return b.toString();
   }
 
-  boolean ignoreRunner(String cln) { return ignoreRunners.contains(cln); }
+  boolean ignoreRunner(String cln) {
+    return ignoreRunners.contains(cln);
+  }
 
   Map<String, Object> overrideSystemProperties() {
     HashMap<String, Object> oldprops = new HashMap<String, Object>();
-    synchronized(System.getProperties()) {
-      for(Map.Entry<String, String> me : sysprops.entrySet()) {
+    synchronized (System.getProperties()) {
+      for (Map.Entry<String, String> me : sysprops.entrySet()) {
         String old = System.getProperty(me.getKey());
         oldprops.put(me.getKey(), old == null ? NULL : old);
       }
-      for(Map.Entry<String, String> me : sysprops.entrySet()) {
+      for (Map.Entry<String, String> me : sysprops.entrySet()) {
         System.setProperty(me.getKey(), me.getValue());
       }
     }
@@ -186,12 +196,12 @@ class RunSettings implements Settings {
   }
 
   void restoreSystemProperties(Map<String, Object> oldprops) {
-    synchronized(System.getProperties()) {
-      for(Map.Entry<String, Object> me : oldprops.entrySet()) {
-        if(me.getValue() == NULL) {
+    synchronized (System.getProperties()) {
+      for (Map.Entry<String, Object> me : oldprops.entrySet()) {
+        if (me.getValue() == NULL) {
           System.clearProperty(me.getKey());
         } else {
-          System.setProperty(me.getKey(), (String)me.getValue());
+          System.setProperty(me.getKey(), (String) me.getValue());
         }
       }
     }
@@ -203,6 +213,8 @@ class RunSettings implements Settings {
   }
 
   static enum Summary {
-    SBT, ONE_LINE, LIST_FAILED
+    SBT,
+    ONE_LINE,
+    LIST_FAILED
   }
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/RunStatistics.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RunStatistics.java
@@ -17,42 +17,49 @@ class RunStatistics {
     this.settings = settings;
   }
 
-  void addTime(long t) { accumulatedTime += t; }
+  void addTime(long t) {
+    accumulatedTime += t;
+  }
 
   synchronized void captureStats(AbstractEvent e) {
     Status s = e.status();
-    if(s == Status.Error || s == Status.Failure) {
+    if (s == Status.Error || s == Status.Failure) {
       failedCount++;
       failedNames.add(e.fullyQualifiedName());
-    }
-    else {
-      if(s == Status.Ignored) ignoredCount++;
+    } else {
+      if (s == Status.Ignored) ignoredCount++;
       else otherCount++;
       otherNames.add(e.fullyQualifiedName());
     }
   }
 
   private String summaryLine() {
-    return (failedCount == 0 ? "All tests passed: " : "Some tests failed: ") +
-      failedCount+" failed, "+ignoredCount+" ignored, "+(failedCount+ignoredCount+otherCount)+" total, "+
-      (accumulatedTime/1000.0)+"s";
+    return (failedCount == 0 ? "All tests passed: " : "Some tests failed: ")
+        + failedCount
+        + " failed, "
+        + ignoredCount
+        + " ignored, "
+        + (failedCount + ignoredCount + otherCount)
+        + " total, "
+        + (accumulatedTime / 1000.0)
+        + "s";
   }
 
   private static String mkString(List<String> l) {
     StringBuilder b = new StringBuilder();
-    for(String s : l) {
-      if(b.length() != 0) b.append(", ");
+    for (String s : l) {
+      if (b.length() != 0) b.append(", ");
       b.append(s);
     }
     return b.toString();
   }
 
   synchronized String createSummary() {
-    switch(settings.summary) {
+    switch (settings.summary) {
       case LIST_FAILED:
-        return failedNames.isEmpty() ?
-          summaryLine() :
-          (summaryLine() + "\n- Failed tests: " + mkString(failedNames));
+        return failedNames.isEmpty()
+            ? summaryLine()
+            : (summaryLine() + "\n- Failed tests: " + mkString(failedNames));
       case ONE_LINE:
         return summaryLine();
       default:

--- a/junit-interface/src/main/java/munit/internal/junitinterface/RunWithFingerprint.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RunWithFingerprint.java
@@ -2,8 +2,12 @@ package munit.internal.junitinterface;
 
 public class RunWithFingerprint extends AbstractAnnotatedFingerprint {
   @Override
-  public String annotationName() { return "org.junit.runner.RunWith"; }
+  public String annotationName() {
+    return "org.junit.runner.RunWith";
+  }
 
   @Override
-  public boolean isModule() { return false; }
+  public boolean isModule() {
+    return false;
+  }
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/Settings.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/Settings.java
@@ -1,13 +1,14 @@
 package munit.internal.junitinterface;
 
 public interface Settings {
-    public boolean trimStackTraces();
-    public static Settings defaults() {
-        return new Settings() {
-            @Override
-            public boolean trimStackTraces() {
-                return true;
-            }
-        };
-    }
+  public boolean trimStackTraces();
+
+  public static Settings defaults() {
+    return new Settings() {
+      @Override
+      public boolean trimStackTraces() {
+        return true;
+      }
+    };
+  }
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/SilentFilterRequest.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/SilentFilterRequest.java
@@ -5,9 +5,7 @@ import org.junit.runner.Runner;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.NoTestsRemainException;
 
-/**
- * A filtered request which ignores NoTestsRemainExceptions.
- */
+/** A filtered request which ignores NoTestsRemainExceptions. */
 final class SilentFilterRequest extends Request {
   private final Request request;
   private final Filter filter;
@@ -17,7 +15,7 @@ final class SilentFilterRequest extends Request {
     this.filter = filter;
   }
 
-  @Override 
+  @Override
   public Runner getRunner() {
     Runner runner = request.getRunner();
     try {

--- a/junit-interface/src/main/java/munit/internal/junitinterface/Tag.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/Tag.java
@@ -1,5 +1,5 @@
 package munit.internal.junitinterface;
 
 public interface Tag {
-    String value();
+  String value();
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/TagFilter.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/TagFilter.java
@@ -7,40 +7,37 @@ import java.lang.annotation.Annotation;
 import java.util.Set;
 
 public class TagFilter extends Filter {
-    final Set<String> includeTags, excludeTags;
+  final Set<String> includeTags, excludeTags;
 
-    public TagFilter(Set<String> includeTags, Set<String> excludeTags) {
-        this.includeTags = includeTags;
-        this.excludeTags = excludeTags;
-    }
+  public TagFilter(Set<String> includeTags, Set<String> excludeTags) {
+    this.includeTags = includeTags;
+    this.excludeTags = excludeTags;
+  }
 
-    @Override
-    public boolean shouldRun(Description description) {
-        if (includeTags.isEmpty() && excludeTags.isEmpty()) return true;
-        boolean isIncluded = includeTags.isEmpty();
-        for (Annotation annotation : description.getAnnotations()) {
-            if (annotation instanceof Tag) {
-                Tag tag = (Tag) annotation;
-                isIncluded = isIncluded || includeTags.contains(tag.value());
-                boolean isExcluded = excludeTags.contains(tag.value());
-                if (isExcluded) {
-                    return false;
-                }
-            }
+  @Override
+  public boolean shouldRun(Description description) {
+    if (includeTags.isEmpty() && excludeTags.isEmpty()) return true;
+    boolean isIncluded = includeTags.isEmpty();
+    for (Annotation annotation : description.getAnnotations()) {
+      if (annotation instanceof Tag) {
+        Tag tag = (Tag) annotation;
+        isIncluded = isIncluded || includeTags.contains(tag.value());
+        boolean isExcluded = excludeTags.contains(tag.value());
+        if (isExcluded) {
+          return false;
         }
-        return isIncluded;
+      }
     }
+    return isIncluded;
+  }
 
-    @Override
-    public String toString() {
-        return "TagFilter{" +
-                "includeTags=" + includeTags +
-                ", excludeTags=" + excludeTags +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "TagFilter{" + "includeTags=" + includeTags + ", excludeTags=" + excludeTags + '}';
+  }
 
-    @Override
-    public String describe() {
-        return toString();
-    }
+  @Override
+  public String describe() {
+    return toString();
+  }
 }

--- a/junit-interface/src/main/java/munit/internal/junitinterface/TaskDefFilter.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/TaskDefFilter.java
@@ -4,8 +4,7 @@ import sbt.testing.TaskDef;
 
 public class TaskDefFilter {
 
-  public TaskDefFilter(ClassLoader testClassLoader) {
-  }
+  public TaskDefFilter(ClassLoader testClassLoader) {}
 
   public boolean shouldRun(TaskDef taskDef) {
     return true;

--- a/junit-interface/src/main/java/munit/internal/junitinterface/TestFilter.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/TestFilter.java
@@ -1,4 +1,5 @@
-// Mostly copied from http://stackoverflow.com/questions/1230706/running-a-subset-of-junit-test-methods/1236782#1236782
+// Mostly copied from
+// http://stackoverflow.com/questions/1230706/running-a-subset-of-junit-test-methods/1236782#1236782
 package munit.internal.junitinterface;
 
 import java.util.HashSet;
@@ -7,42 +8,37 @@ import java.util.regex.Pattern;
 import org.junit.runner.Description;
 import org.junit.runner.manipulation.Filter;
 
-public final class TestFilter extends Filter
-{
+public final class TestFilter extends Filter {
   private static final String DELIMITER = "\\,";
 
   private final HashSet<String> ignored = new HashSet<String>();
   private final String[] testPatterns;
   private final EventDispatcher ed;
 
-  public TestFilter(String testFilter, EventDispatcher ed)
-  {
+  public TestFilter(String testFilter, EventDispatcher ed) {
     this.ed = ed;
     this.testPatterns = testFilter.split(DELIMITER);
   }
 
   @Override
-  public String describe()
-  {
+  public String describe() {
     return "Filters out all tests not explicitly named in the '-tests=' option.";
   }
 
   @Override
-  public boolean shouldRun(Description d)
-  {
+  public boolean shouldRun(Description d) {
     String displayName = d.getDisplayName();
 
     // We get asked both if we should run the class/suite, as well as the individual tests
     // So let the suite always run, so we can evaluate the individual test cases
-    if(displayName.indexOf('(') == -1) return true;
+    if (displayName.indexOf('(') == -1) return true;
     String testName = displayName.substring(0, displayName.indexOf('('));
 
     // JUnit calls this multiple times per test and we don't want to print a new "test ignored"
     // message each time
-    if(ignored.contains(testName)) return false;
+    if (ignored.contains(testName)) return false;
 
-    for(String p : testPatterns)
-      if(Pattern.matches(p, testName)) return true;
+    for (String p : testPatterns) if (Pattern.matches(p, testName)) return true;
 
     ignored.add(testName);
     ed.testIgnored(d);

--- a/munit/jvm/src/main/java/munit/IgnoreSuite.java
+++ b/munit/jvm/src/main/java/munit/IgnoreSuite.java
@@ -4,5 +4,4 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Retention;
 
 @Retention(RetentionPolicy.RUNTIME)
-public @interface IgnoreSuite {
-}
+public @interface IgnoreSuite {}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,5 +8,6 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.6.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")
+addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.6.1")
 
 libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.1.7"

--- a/tests/shared/src/main/scala/munit/Issue285FrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/Issue285FrameworkSuite.scala
@@ -22,13 +22,13 @@ class Issue285FrameworkSuite extends FunSuite {
     }
   }
   override def munitFixtures: List[Fixture[Unit]] = List(hello)
-  override def munitTimeout: Duration = Duration(1, "ms")
+  override def munitTimeout: Duration = Duration(5, "ms")
   test("issue-285-ok") {
     ()
   }
   test("issue-285-fail") {
     val promise = Promise[Unit]()
-    PlatformCompat.setTimeout(3) {
+    PlatformCompat.setTimeout(20) {
       promise.trySuccess(())
     }
     promise.future
@@ -48,7 +48,7 @@ object Issue285FrameworkSuite
          |  + issue-285-ok <elapsed time>
          |beforeEach - issue-285-fail
          |afterEach - issue-285-fail
-         |==> X munit.Issue285FrameworkSuite.issue-285-fail  <elapsed time>java.util.concurrent.TimeoutException: test timed out after 1 millisecond
+         |==> X munit.Issue285FrameworkSuite.issue-285-fail  <elapsed time>java.util.concurrent.TimeoutException: test timed out after 5 milliseconds
          |beforeEach - issue-285-ok
          |afterEach - issue-285-ok
          |  + issue-285-ok-1 <elapsed time>


### PR DESCRIPTION
Previously, we didn't use any code formatter for the Java sources in this project. This PR adds google-java-format so that we have a similar formatting setup for Java as we do for Scala.