### PR TITLE
Remove `-XX:+CMSClassUnloadingEnabled` from .jvmopts

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,5 +3,4 @@
 -Xmx2G
 -XX:ReservedCodeCacheSize=1024m
 -XX:+TieredCompilation
--XX:+CMSClassUnloadingEnabled
 -Dfile.encoding=UTF-8


### PR DESCRIPTION
This causes JDK 17 to crash on my machine.