### PR TITLE
Enable -Xlint and -Werror

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -237,7 +237,7 @@ def check[T](
 
 check("basic", List(1, 2), Some(1))
 check("empty", List(), Some(1))
-check("null", List(null, 2), Some(null))
+check("null", List(null, "more"), Some(null))
 ```
 
 When declaring tests in a helper function, it's useful to pass around an

--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -1,9 +1,12 @@
 package munit
 
+import language.implicitConversions
+
 import org.scalacheck.Prop
 import org.scalacheck.{Test => ScalaCheckTest}
 import org.scalacheck.util.Pretty
 import org.scalacheck.rng.Seed
+import scala.annotation.nowarn
 import scala.util.Success
 import scala.util.Failure
 import scala.util.Try
@@ -25,6 +28,7 @@ trait ScalaCheckSuite extends FunSuite {
   // Allow property bodies of type Unit
   // This is done to support using MUnit assertions in property bodies
   // instead of returning a Boolean.
+  @nowarn("msg=used")
   implicit def unitToProp(unit: Unit): Prop = Prop.passed
 
   override def munitTestTransforms: List[TestTransform] =

--- a/munit/js-native/src/main/scala/munit/internal/junitinterface/JUnitReporter.scala
+++ b/munit/js-native/src/main/scala/munit/internal/junitinterface/JUnitReporter.scala
@@ -7,6 +7,7 @@ package munit.internal.junitinterface
 import munit.internal.console.AnsiColors
 import sbt.testing._
 import munit.internal.PlatformCompat
+import scala.annotation.nowarn
 
 final class JUnitReporter(
     eventHandler: EventHandler,
@@ -35,6 +36,7 @@ final class JUnitReporter(
     }
     emitEvent(method, Status.Ignored)
   }
+  @nowarn("msg=used")
   def reportAssumptionViolation(
       method: String,
       timeInSeconds: Double,
@@ -219,6 +221,7 @@ final class JUnitReporter(
       .map(_.getFileName)
       .orNull
 
+  @nowarn("msg=used")
   private def stackTraceElementToString(
       e: StackTraceElement,
       testFileName: String

--- a/munit/js-native/src/main/scala/munit/internal/junitinterface/JUnitRunner.scala
+++ b/munit/js-native/src/main/scala/munit/internal/junitinterface/JUnitRunner.scala
@@ -6,7 +6,9 @@ package munit.internal.junitinterface
 
 import sbt.testing._
 import munit.internal.PlatformCompat
+import scala.annotation.nowarn
 
+@nowarn("msg=used")
 final class JUnitRunner(
     val args: Array[String],
     _remoteArgs: Array[String],

--- a/munit/js-native/src/main/scala/org/junit/experimental/categories/Category.scala
+++ b/munit/js-native/src/main/scala/org/junit/experimental/categories/Category.scala
@@ -1,5 +1,7 @@
 package org.junit.experimental.categories
 
 import scala.annotation.Annotation
+import scala.annotation.nowarn
 
+@nowarn("msg=used")
 class Category(classes: Array[Class[_]]) extends Annotation

--- a/munit/js-native/src/main/scala/org/junit/runner/RunWith.scala
+++ b/munit/js-native/src/main/scala/org/junit/runner/RunWith.scala
@@ -1,5 +1,7 @@
 package org.junit.runner
 
 import scala.annotation.Annotation
+import scala.annotation.nowarn
 
+@nowarn("msg=used")
 class RunWith(cls: Class[_]) extends Annotation

--- a/munit/js/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/js/src/main/scala/munit/internal/PlatformCompat.scala
@@ -3,10 +3,11 @@ package munit.internal
 import scala.scalajs.reflect.Reflect
 import sbt.testing.TaskDef
 import munit.MUnitRunner
-import scala.concurrent.Future
 import sbt.testing.Task
 import sbt.testing.EventHandler
 import sbt.testing.Logger
+import scala.annotation.nowarn
+import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
@@ -36,7 +37,7 @@ object PlatformCompat {
       ec: ExecutionContext
   ): Future[T] = {
     val onComplete = Promise[T]()
-    val timeoutHandle = timers.setTimeout(duration.toMillis) {
+    val timeoutHandle = timers.setTimeout(duration.toMillis.toDouble) {
       onComplete.tryFailure(
         new TimeoutException(s"test timed out after $duration")
       )
@@ -65,6 +66,7 @@ object PlatformCompat {
   def isJS: Boolean = true
   def isNative: Boolean = false
 
+  @nowarn("msg=used")
   def newRunner(
       taskDef: TaskDef,
       classLoader: ClassLoader

--- a/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
@@ -7,6 +7,7 @@ import scala.scalanative.reflect.Reflect
 import sbt.testing.Task
 import sbt.testing.EventHandler
 import sbt.testing.Logger
+import scala.annotation.nowarn
 import scala.concurrent.Await
 import scala.concurrent.Awaitable
 import scala.concurrent.duration.Duration
@@ -26,6 +27,7 @@ object PlatformCompat {
     task.execute(eventHandler, loggers)
     Future.successful(())
   }
+  @nowarn("msg=used")
   def waitAtMost[T](
       startFuture: () => Future[T],
       duration: Duration,
@@ -47,6 +49,7 @@ object PlatformCompat {
   def isJS: Boolean = false
   def isNative: Boolean = true
 
+  @nowarn("msg=used")
   def newRunner(
       taskDef: TaskDef,
       classLoader: ClassLoader

--- a/munit/native/src/main/scala/munit/internal/junitinterface/JUnitTask.scala
+++ b/munit/native/src/main/scala/munit/internal/junitinterface/JUnitTask.scala
@@ -7,7 +7,6 @@ package munit.internal.junitinterface
 import munit.internal.PlatformCompat
 import org.junit.runner.notification.RunNotifier
 import sbt.testing._
-import scala.concurrent.ExecutionContext.Implicits.global
 
 /* Implementation note: In JUnitTask we use Future[Try[Unit]] instead of simply
  * Future[Unit]. This is to prevent Scala's Future implementation to box/wrap

--- a/munit/shared/src/main/scala-2.13/munit/internal/Compat.scala
+++ b/munit/shared/src/main/scala-2.13/munit/internal/Compat.scala
@@ -1,5 +1,7 @@
 package munit.internal
 
+import language.reflectiveCalls
+
 object Compat {
   type LazyList[+T] = scala.LazyList[T]
   val LazyList = scala.LazyList

--- a/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
@@ -2,6 +2,7 @@ package munit.internal
 
 import munit.Clue
 import munit.Location
+import scala.language.implicitConversions
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 

--- a/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
@@ -4,6 +4,7 @@ import munit.Clue
 import munit.Location
 import scala.quoted._
 import scala.language.experimental.macros
+import scala.language.implicitConversions
 
 object MacroCompat {
 
@@ -15,7 +16,7 @@ object MacroCompat {
   def locationImpl()(using Quotes): Expr[Location] = {
     import quotes.reflect._
     val pos = Position.ofMacroExpansion
-    val path = pos.sourceFile.jpath.toString
+    val path = pos.sourceFile.path
     val startLine = pos.startLine + 1
     '{ new Location(${ Expr(path) }, ${ Expr(startLine) }) }
   }

--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -4,9 +4,10 @@ import munit.internal.console.{Lines, Printers, StackTraces}
 import munit.internal.difflib.ComparisonFailExceptionHandler
 import munit.internal.difflib.Diffs
 
+import scala.annotation.nowarn
+import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
-import scala.collection.mutable
 import munit.internal.console.AnsiColors
 import org.junit.AssumptionViolatedException
 import munit.internal.MacroCompat
@@ -37,7 +38,7 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
   def assume(
       cond: Boolean,
       clue: => Any = "assumption failed"
-  )(implicit loc: Location): Unit = {
+  )(implicit @nowarn loc: Location): Unit = {
     StackTraces.dropInside {
       if (!cond) {
         throw new AssumptionViolatedException(munitPrint(clue))
@@ -95,7 +96,7 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
     StackTraces.dropInside {
       if (!compare.isEqual(obtained, expected)) {
         (obtained, expected) match {
-          case (a: Array[_], b: Array[_]) if a.sameElements(b) =>
+          case (a: Array[_], b: Array[_]) if a.sameElements[Any](b) =>
             // Special-case error message when comparing arrays. See
             // https://github.com/scalameta/munit/pull/393 and
             // https://github.com/scalameta/munit/issues/339 for a related

--- a/munit/shared/src/main/scala/munit/TestOptions.scala
+++ b/munit/shared/src/main/scala/munit/TestOptions.scala
@@ -46,6 +46,8 @@ object TestOptions extends TestOptionsConversions {
 
 trait TestOptionsConversions {
 
+  import language.implicitConversions
+
   /**
    * Implicitly create a TestOptions given a test name.
    * This allows writing `test("name") { ... }` even if `test` accepts a `TestOptions`

--- a/munit/shared/src/main/scala/munit/ValueTransforms.scala
+++ b/munit/shared/src/main/scala/munit/ValueTransforms.scala
@@ -26,7 +26,7 @@ trait ValueTransforms { this: BaseFunSuite =>
       val nested: Future[Future[Any]] = future.map { value =>
         val transformed = munitValueTransforms.iterator
           .map(fn => fn(value))
-          .collectFirst { case Some(future) => future }
+          .collectFirst { case Some(f) => f }
         transformed match {
           case Some(f) => flattenFuture(f)
           case None    => Future.successful(value)

--- a/munit/shared/src/main/scala/munit/internal/FutureCompat.scala
+++ b/munit/shared/src/main/scala/munit/internal/FutureCompat.scala
@@ -1,8 +1,8 @@
 package munit.internal
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Try
-import scala.concurrent.ExecutionContext
 
 object FutureCompat {
   implicit class ExtensionFuture[T](f: Future[T]) {

--- a/munit/shared/src/main/scala/munit/internal/difflib/Diffs.scala
+++ b/munit/shared/src/main/scala/munit/internal/difflib/Diffs.scala
@@ -7,7 +7,7 @@ object Diffs {
   def create(obtained: String, expected: String): Diff =
     new Diff(obtained, expected)
 
-  @deprecated("")
+  @deprecated("", since="")
   def assertNoDiff(
       obtained: String,
       expected: String,

--- a/munit/shared/src/main/scala/munit/internal/difflib/Equalizer.scala
+++ b/munit/shared/src/main/scala/munit/internal/difflib/Equalizer.scala
@@ -6,7 +6,7 @@ trait Equalizer[T] {
 object Equalizer {
   def default[T]: Equalizer[T] = new Equalizer[T] {
     override def equals(original: T, revised: T): Boolean = {
-      original.equals(revised)
+      original == revised   //original.equals(revised)
     }
   }
 }

--- a/tests/jvm/src/test/scala/munit/AsyncFunFixtureOrderSuite.scala
+++ b/tests/jvm/src/test/scala/munit/AsyncFunFixtureOrderSuite.scala
@@ -4,7 +4,7 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 
 class AsyncFunFixtureOrderSuite extends FunSuite {
-  val latch: Promise[Unit] = Promise[Unit]
+  val latch: Promise[Unit] = Promise[Unit]()
   var completedFromTest: Option[Boolean] = None
   var completedFromTeardown: Option[Boolean] = None
 

--- a/tests/shared/src/test/scala/munit/PrintersSuite.scala
+++ b/tests/shared/src/test/scala/munit/PrintersSuite.scala
@@ -63,7 +63,7 @@ class PrintersSuite extends FunSuite { self =>
 
   check(
     "list",
-    List(1, 2, 3, List(4, 5, List(6, 7))),
+    List[Any](1, 2, 3, List[Any](4, 5, List(6, 7))),
     """|List(
        |  1,
        |  2,


### PR DESCRIPTION
Linting on 2.13 such as required empty args,
inferred Any in sameElements of Array[_],
Timeout is double-valued, avoid Any.equals,
some elements unused, deprecations.
Allow JavaConverters.

Can't use nowarn and unused annotations
under 2.11/2.12.