### PR TITLE
Draft: Change test return types from Any to overridable type MunitRes <: Any

### DIFF
--- a/munit/shared/src/main/scala/munit/FunFixtures.scala
+++ b/munit/shared/src/main/scala/munit/FunFixtures.scala
@@ -7,6 +7,7 @@ import scala.util.Success
 import scala.util.Failure
 
 trait FunFixtures { self: BaseFunSuite =>
+  override type MunitRes = Any
 
   class FunFixture[T] private (
       val setup: TestOptions => Future[T],
@@ -20,12 +21,12 @@ trait FunFixtures { self: BaseFunSuite =>
       )
 
     def test(name: String)(
-        body: T => Any
+        body: T => MunitRes
     )(implicit loc: Location): Unit = {
       fixture.test(TestOptions(name))(body)
     }
     def test(options: TestOptions)(
-        body: T => Any
+        body: T => MunitRes
     )(implicit loc: Location): Unit = {
       self.test(options) {
         implicit val ec = munitExecutionContext
@@ -53,7 +54,7 @@ trait FunFixtures { self: BaseFunSuite =>
   object FunFixture {
     def apply[T](
         setup: TestOptions => T,
-        teardown: T => Unit
+        teardown: T => MunitRes
     ): FunFixture[T] = {
       implicit val ec = munitExecutionContext
       async[T](

--- a/munit/shared/src/main/scala/munit/FunSuite.scala
+++ b/munit/shared/src/main/scala/munit/FunSuite.scala
@@ -8,7 +8,9 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 import java.util.concurrent.TimeUnit
 
-abstract class FunSuite extends BaseFunSuite
+abstract class FunSuite extends BaseFunSuite {
+  override type MunitRes = Any
+}
 
 trait BaseFunSuite
     extends Suite
@@ -19,16 +21,18 @@ trait BaseFunSuite
     with SuiteTransforms
     with ValueTransforms { self =>
 
+  type MunitRes <: Any
+
   final val munitTestsBuffer: mutable.ListBuffer[Test] =
     mutable.ListBuffer.empty[Test]
   def munitTests(): Seq[Test] = {
     munitSuiteTransform(munitTestsBuffer.toList)
   }
 
-  def test(name: String)(body: => Any)(implicit loc: Location): Unit = {
+  def test(name: String)(body: => MunitRes)(implicit loc: Location): Unit = {
     test(new TestOptions(name))(body)
   }
-  def test(options: TestOptions)(body: => Any)(implicit loc: Location): Unit = {
+  def test(options: TestOptions)(body: => MunitRes)(implicit loc: Location): Unit = {
     munitTestsBuffer += munitTestTransform(
       new Test(
         options.name,

--- a/munit/shared/src/main/scala/munit/FunSuite.scala
+++ b/munit/shared/src/main/scala/munit/FunSuite.scala
@@ -21,6 +21,11 @@ trait BaseFunSuite
     with SuiteTransforms
     with ValueTransforms { self =>
 
+  /**
+   * Override type to constrain the types allowed to be returned by your tests.
+   *
+   * This is here mostly for library authors or util authors that wish to constrain users, at compile time, in order to prevent writing wrong tests.
+   */
   type MunitRes <: Any
 
   final val munitTestsBuffer: mutable.ListBuffer[Test] =


### PR DESCRIPTION
This is really a starting point for a discussion, but that has real code to showcase :D I'll hapilly move it to an issue.

The idea behind this is to let libraries that build on top of `munit` to constrain the return type of tests, particularly useful would be for uses in `munit-cats-effect` where one could then define a base class for cats-effect tests like:

```scala
import munit._
import cats.effect._

abstract class CatsEffectFunSuite extends BaseFunSuite {
  override type MunitRes = IO[Unit]
}
```

As far as I can tell this change would impact other libraries, and not end users.