### PR TITLE
Update docs for usage with mill

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,13 +37,11 @@ testFrameworks += new TestFramework("munit.Framework")
 **Mill**
 
 ```scala
-object test extends Tests {
+object test extends Tests with TestModule.Munit {
   def ivyDeps =
     Agg(
       ivy"org.scalameta::munit::@STABLE_VERSION@"
     )
-
-  def testFrameworks = Seq("munit.Framework")
 }
 ```
 


### PR DESCRIPTION
extending `TestModule` is now the preferred way.
also `testFrameworks` (plural) is deprecated in favor of `testFramework` anyway