### PR TITLE
Make flaky tag work with Scalacheck suites

### DIFF
--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -10,7 +10,6 @@ import scala.util.Try
 import munit.internal.FutureCompat._
 
 trait ScalaCheckSuite extends FunSuite {
-
   def property(
       name: String
   )(body: => Prop)(implicit loc: Location): Unit = {

--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -29,7 +29,7 @@ trait ScalaCheckSuite extends FunSuite {
   implicit def unitToProp(unit: Unit): Prop = Prop.passed
 
   override def munitTestTransforms: List[TestTransform] =
-    super.munitTestTransforms :+ scalaCheckPropTransform
+    scalaCheckPropTransform +: super.munitTestTransforms
 
   protected def scalaCheckTestParameters = ScalaCheckTest.Parameters.default
 

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/MUnitRunNotifier.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/MUnitRunNotifier.scala
@@ -9,7 +9,7 @@ class MUnitRunNotifier(reporter: JUnitReporter) extends RunNotifier {
   var ignored = 0
   var total = 0
   var startedTimestamp = 0L
-  val isFailed: mutable.Set[String] = mutable.Set.empty[String]
+  val isReported: mutable.Set[Description] = mutable.Set.empty[Description]
   override def fireTestSuiteStarted(description: Description): Unit = {
     reporter.reportTestSuiteStarted()
   }
@@ -23,11 +23,13 @@ class MUnitRunNotifier(reporter: JUnitReporter) extends RunNotifier {
   }
   override def fireTestIgnored(description: Description): Unit = {
     ignored += 1
+    isReported += description
     reporter.reportTestIgnored(description.getMethodName)
   }
   override def fireTestAssumptionFailed(
       failure: notification.Failure
   ): Unit = {
+    isReported += failure.description
     reporter.reportAssumptionViolation(
       failure.description.getMethodName,
       elapsedMillis(),
@@ -36,7 +38,7 @@ class MUnitRunNotifier(reporter: JUnitReporter) extends RunNotifier {
   }
   override def fireTestFailure(failure: notification.Failure): Unit = {
     val methodName = failure.description.getMethodName
-    isFailed += methodName
+    isReported += failure.description
     reporter.reportTestFailed(
       methodName,
       failure.ex,
@@ -46,7 +48,7 @@ class MUnitRunNotifier(reporter: JUnitReporter) extends RunNotifier {
   override def fireTestFinished(description: Description): Unit = {
     val methodName = description.getMethodName
     total += 1
-    if (!isFailed(methodName)) {
+    if (!isReported(description)) {
       reporter.reportTestPassed(
         methodName,
         elapsedMillis()

--- a/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
@@ -38,6 +38,13 @@ class ScalaCheckFrameworkSuite extends ScalaCheckSuite {
     }
   }
 
+  override def munitFlakyOK: Boolean = true
+  test("flaky test".flaky) {
+    forAll { (i: Int) =>
+      assertEquals(1, 0)
+    }
+  }
+
 }
 
 object ScalaCheckFrameworkSuite
@@ -78,5 +85,6 @@ object ScalaCheckFrameworkSuite
          |Falsified after 0 passed tests.
          |> ARG_0: -1
          |> ARG_0_ORIGINAL: 2147483647
+         |==> skipped munit.ScalaCheckFrameworkSuite.flaky test - ignoring flaky test failure
          |""".stripMargin
     )


### PR DESCRIPTION
Previously, the Scalacheck suite transform was registered after the
`.flaky` transform so a flaky test would fail even if it was OK to
ignore flaky failures. Reordering the transforms fixes the issue.