### PR TITLE
feat: take into account TaskDefs with only TestSelectors.

### DIFF
--- a/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
@@ -78,6 +78,28 @@ class RunSettings implements Settings {
     this.trimStackTraces = trimStackTraces;
   }
 
+  public RunSettings withTestFilter(String newTestFilter) {
+    String ignoreRunners = String.join(",", this.ignoreRunners);
+    return new RunSettings(
+        this.color,
+        this.decodeScalaNames,
+        this.verbose,
+        this.useSbtLoggers,
+        this.useBufferedLoggers,
+        this.trimStackTraces,
+        this.summary,
+        this.logAssert,
+        ignoreRunners,
+        this.logExceptionClass,
+        this.sysprops,
+        this.globPatterns,
+        this.includeCategories,
+        this.excludeCategories,
+        this.includeTags,
+        this.excludeTags,
+        newTestFilter);
+  }
+
   String decodeName(String name) {
     return decodeScalaNames ? decodeScalaName(name) : name;
   }

--- a/tests/jvm/src/test/scala/munit/TestSelectorSuite.scala
+++ b/tests/jvm/src/test/scala/munit/TestSelectorSuite.scala
@@ -1,0 +1,122 @@
+package munit
+
+import sbt.testing.Event
+import sbt.testing.EventHandler
+import sbt.testing.Selector
+import sbt.testing.Status
+import sbt.testing.SuiteSelector
+import sbt.testing.TaskDef
+import sbt.testing.TestSelector
+import scala.collection.mutable
+import sbt.testing.Runner
+
+/**
+ * Dummy test suite which is needed by TestSelectorSuite
+ */
+class MyTestSuite extends FunSuite {
+
+  test("testFoo") {
+    assert(true, "Test should pass")
+  }
+
+  test("testBar") {
+    assert(true, "Test should pass")
+  }
+}
+
+/**
+ * Check if TestSelector's are correctly handled by Munit.
+ * Execute prepared TaskDef's using manually created instances of sbt.testing.{Framework and Runner}.
+ */
+class TestSelectorSuite extends FunSuite {
+  val framework = new Framework();
+  val runner: Runner = framework.runner(
+    Array.empty,
+    Array.empty,
+    this.getClass().getClassLoader()
+  );
+
+  val fingerprint = framework.munitFingerprint
+
+  /**
+   * Reference to the collection which will contain fully qualified names of executed tests.
+   * Only after finished execution it's safe to convert this mutable collection to immutable one.
+   */
+  private def getEventHandler(): (mutable.ListBuffer[String], EventHandler) = {
+    val executedItems = new mutable.ListBuffer[String]
+    val eventHandler = new EventHandler {
+      override def handle(event: Event) =
+        if (event.status() == Status.Success) {
+          executedItems += event.fullyQualifiedName()
+        }
+    }
+    (executedItems, eventHandler)
+  }
+
+  private def getTaskDefs(selectors: Array[Selector]): Array[TaskDef] = {
+    Array(
+      new TaskDef("munit.MyTestSuite", fingerprint, false, selectors)
+    )
+  }
+
+  test("runAllViaSuiteSelector") {
+    val selectors = Array[Selector](
+      new SuiteSelector
+    )
+    val taskDefs = Array(
+      new TaskDef("munit.MyTestSuite", fingerprint, false, selectors)
+    )
+
+    val tasks = runner.tasks(taskDefs)
+    assertEquals(tasks.size, 1)
+    val task = tasks(0)
+
+    val (executedItems, eventHandler) = getEventHandler()
+
+    task.execute(eventHandler, Nil.toArray)
+    assertEquals(
+      executedItems.toSet,
+      Set("munit.MyTestSuite.testBar", "munit.MyTestSuite.testFoo")
+    )
+  }
+
+  test("runAllViaTestSelectors") {
+    val selectors = Array[Selector](
+      new TestSelector("testFoo"),
+      new TestSelector("testBar")
+    )
+    val taskDefs = getTaskDefs(selectors)
+
+    val tasks = runner.tasks(taskDefs)
+    assertEquals(tasks.size, 1)
+    val task = tasks(0)
+
+    val (executedItems, eventHandler) = getEventHandler()
+
+    task.execute(eventHandler, Nil.toArray)
+    assertEquals(
+      executedItems.toSet,
+      Set("munit.MyTestSuite.testBar", "munit.MyTestSuite.testFoo")
+    )
+  }
+
+  test("runOnlyOne") {
+    val selectors = Array[Selector](
+      new TestSelector("testFoo")
+    )
+    val taskDefs = getTaskDefs(selectors)
+
+    val tasks = runner.tasks(taskDefs)
+    assertEquals(tasks.size, 1)
+    val task = tasks(0)
+
+    val (executedItems, eventHandler) = getEventHandler()
+
+    task.execute(eventHandler, Nil.toArray)
+    assertEquals(
+      executedItems.toSet,
+      Set("munit.MyTestSuite.testFoo")
+    )
+
+  }
+}


### PR DESCRIPTION
`TestSelector` can be used to create `TaskDef` which should only execute selected tests from the given test class.

More info can be found at https://github.com/sbt/junit-interface/pull/108 (the changes are almost the same)

~Could you point me how to add a test for that feature and for compatibility?~
That was a silly question, I've already done tests for this in Junit, why not use them here as well.


tl;dr why
This will allow Metals to run a single munit test from the whole suite.