### PR TITLE
feat: better "obtained empty" help message

### DIFF
--- a/munit/shared/src/main/scala/munit/internal/difflib/Diffs.scala
+++ b/munit/shared/src/main/scala/munit/internal/difflib/Diffs.scala
@@ -39,7 +39,11 @@ object Diffs {
       printObtainedAsStripMargin: Boolean
   )(implicit loc: Location): Boolean = {
     if (obtained.isEmpty && !expected.isEmpty) {
-      handler.handle("Obtained empty output!", obtained, expected, loc)
+      val msg = 
+        s"""|Obtained empty output!
+            |=> Expected:
+            |$expected""".stripMargin
+      handler.handle(msg, obtained, expected, loc)
     }
     val diff = new Diff(obtained, expected)
     if (diff.isEmpty) true

--- a/munit/shared/src/main/scala/munit/internal/difflib/Diffs.scala
+++ b/munit/shared/src/main/scala/munit/internal/difflib/Diffs.scala
@@ -39,7 +39,7 @@ object Diffs {
       printObtainedAsStripMargin: Boolean
   )(implicit loc: Location): Boolean = {
     if (obtained.isEmpty && !expected.isEmpty) {
-      val msg = 
+      val msg =
         s"""|Obtained empty output!
             |=> Expected:
             |$expected""".stripMargin

--- a/tests/shared/src/test/scala/munit/ComparisonFailExceptionSuite.scala
+++ b/tests/shared/src/test/scala/munit/ComparisonFailExceptionSuite.scala
@@ -56,23 +56,17 @@ class ComparisonFailExceptionSuite extends BaseSuite {
 
   test("assert-no-diff-obtained-empty") {
     val e = intercept[ComparisonFailException] {
-      assertNoDiff(
-        "",
-        """|first line
-           |second line
-           |""".stripMargin
-      )
+      assertNoDiff("", "Lorem ipsum")
     }
     assertNoDiff(
       e.getMessage(),
       """|ComparisonFailExceptionSuite.scala:59
          |58:    val e = intercept[ComparisonFailException] {
-         |59:      assertNoDiff(
-         |60:        "",
+         |59:      assertNoDiff("", "Lorem ipsum")
+         |60:    }
          |Obtained empty output!
          |=> Expected:
-         |first line
-         |second line
+         |Lorem ipsum
          |""".stripMargin
     )
   }

--- a/tests/shared/src/test/scala/munit/ComparisonFailExceptionSuite.scala
+++ b/tests/shared/src/test/scala/munit/ComparisonFailExceptionSuite.scala
@@ -54,4 +54,27 @@ class ComparisonFailExceptionSuite extends BaseSuite {
     )
   }
 
+  test("assert-no-diff-obtained-empty") {
+    val e = intercept[ComparisonFailException] {
+      assertNoDiff(
+        "",
+        """|first line
+           |second line
+           |""".stripMargin
+      )
+    }
+    assertNoDiff(
+      e.getMessage(),
+      """|ComparisonFailExceptionSuite.scala:59
+         |58:    val e = intercept[ComparisonFailException] {
+         |59:      assertNoDiff(
+         |60:        "",
+         |Obtained empty output!
+         |=> Expected:
+         |first line
+         |second line
+         |""".stripMargin
+    )
+  }
+
 }


### PR DESCRIPTION
Previously, when one used `assertNoDiff` and obtained string was empty there was no clue what does `expected` looks like. Because of that, sometimes it wasn't clear which comparison fails.

Now, in the case when `obtained` is empty, `expected` is being printed.