### PR TITLE
Publish for Scala 3 + Native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ def previousVersion = "0.7.0"
 def scala213 = "2.13.6"
 def scala212 = "2.12.14"
 def scala211 = "2.11.12"
-def scala3 = "3.0.1"
+def scala3 = "3.1.1"
 def junitVersion = "4.13.2"
 def gcp = "com.google.cloud" % "google-cloud-storage" % "1.115.0"
 inThisBuild(
@@ -53,8 +53,10 @@ addCommandAlias(
 )
 val isPreScala213 = Set[Option[(Long, Long)]](Some((2, 11)), Some((2, 12)))
 val scala2Versions = List(scala213, scala212, scala211)
+
 val scala3Versions = List(scala3)
 val allScalaVersions = scala2Versions ++ scala3Versions
+
 def isNotScala211(v: Option[(Long, Long)]): Boolean = !v.contains((2, 11))
 def isScala2(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2)
 val isScala3Setting = Def.setting {
@@ -95,18 +97,21 @@ lazy val mimaEnable: List[Def.Setting[_]] = List(
     else Set("org.scalameta" % moduleName.value % previousVersion)
   }
 )
+
 val sharedJVMSettings: List[Def.Setting[_]] = List(
   crossScalaVersions := allScalaVersions
 ) ++ mimaEnable
+
 val sharedJSSettings: List[Def.Setting[_]] = List(
   skipIdeaSettings,
   crossScalaVersions := allScalaVersions.filterNot(_.startsWith("0."))
 )
 val sharedJSConfigure: Project => Project =
   _.disablePlugins(MimaPlugin)
+
 val sharedNativeSettings: List[Def.Setting[_]] = List(
   skipIdeaSettings,
-  crossScalaVersions := scala2Versions
+  crossScalaVersions := allScalaVersions
 )
 val sharedNativeConfigure: Project => Project =
   _.disablePlugins(ScalafixPlugin, MimaPlugin)
@@ -242,7 +247,7 @@ lazy val munitScalacheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     libraryDependencies += {
       val partialVersion = CrossVersion.partialVersion(scalaVersion.value)
       if (isNotScala211(partialVersion))
-        "org.scalacheck" %%% "scalacheck" % "1.15.4"
+        "org.scalacheck" %%% "scalacheck" % "1.16.0"
       else
         "org.scalacheck" %%% "scalacheck" % "1.15.2"
     }
@@ -256,6 +261,7 @@ lazy val munitScalacheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .jsConfigure(sharedJSConfigure)
   .jsSettings(sharedJSSettings)
+
 lazy val munitScalacheckJVM = munitScalacheck.jvm
 lazy val munitScalacheckJS = munitScalacheck.js
 lazy val munitScalacheckNative = munitScalacheck.native

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ import com.typesafe.tools.mima.core.MissingTypesProblem
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import sbtcrossproject.CrossPlugin.autoImport.CrossType
 import scala.collection.mutable
-val scalaJSVersion = "1.6.0"
-val scalaNativeVersion = "0.4.0"
+val scalaJSVersion = "1.10.0"
+val scalaNativeVersion = "0.4.4"
 def previousVersion = "0.7.0"
 def scala213 = "2.13.6"
 def scala212 = "2.12.14"

--- a/munit/non-jvm/src/main/scala/munit/Framework.scala
+++ b/munit/non-jvm/src/main/scala/munit/Framework.scala
@@ -5,12 +5,12 @@ import munit.internal.junitinterface.CustomRunners
 import munit.internal.junitinterface.JUnitFramework
 
 class Framework extends JUnitFramework {
-  override val name = "munit"
-  val munitFingerprint = new CustomFingerprint("munit.Suite", isModule = false)
+  override def name(): String = "munit"
+  val munitFingerprint = new CustomFingerprint("munit.Suite", _isModule = false)
   val customRunners = new CustomRunners(
     List(
       munitFingerprint,
-      new CustomFingerprint("munit.Suite", isModule = true)
+      new CustomFingerprint("munit.Suite", _isModule = true)
     )
   )
 }

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/CustomFingerprint.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/CustomFingerprint.scala
@@ -4,8 +4,9 @@ import sbt.testing.SubclassFingerprint
 
 class CustomFingerprint(
     val suite: String,
-    val isModule: Boolean
+    _isModule: Boolean
 ) extends SubclassFingerprint {
+  override def isModule(): Boolean = _isModule
   override def superclassName(): String = suite
   override def requireNoArgConstructor(): Boolean = true
 }

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitEvent.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitEvent.scala
@@ -8,11 +8,16 @@ import sbt.testing._
 
 final class JUnitEvent(
     taskDef: TaskDef,
-    val fullyQualifiedName: String,
-    val status: Status,
-    val selector: Selector,
-    val throwable: OptionalThrowable = new OptionalThrowable,
-    val duration: Long = -1L
+    _fullyQualifiedName: String,
+    _status: Status,
+    _selector: Selector,
+    _throwable: OptionalThrowable = new OptionalThrowable,
+    _duration: Long = -1L
 ) extends Event {
-  def fingerprint: Fingerprint = taskDef.fingerprint
+  override def status(): Status = _status
+  override def selector(): Selector = _selector
+  override def throwable(): OptionalThrowable = _throwable
+  override def duration(): Long = _duration
+  override def fullyQualifiedName(): String = _fullyQualifiedName
+  override def fingerprint(): Fingerprint = taskDef.fingerprint()
 }

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitFramework.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitFramework.scala
@@ -8,7 +8,7 @@ import sbt.testing._
 
 abstract class JUnitFramework extends Framework {
 
-  val name: String = "Scala.js JUnit test framework"
+  override def name(): String = "Scala.js JUnit test framework"
 
   def customRunners: CustomRunners
 

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitReporter.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitReporter.scala
@@ -91,7 +91,7 @@ final class JUnitReporter(
       throwable: OptionalThrowable = new OptionalThrowable
   ): Unit = {
     val testName =
-      taskDef.fullyQualifiedName + "." +
+      taskDef.fullyQualifiedName() + "." +
         settings.decodeName(method)
     val selector = new TestSelector(testName)
     eventHandler.handle(
@@ -215,7 +215,7 @@ final class JUnitReporter(
 
   private def findTestFileName(trace: Array[StackTraceElement]): String =
     trace
-      .find(_.getClassName == taskDef.fullyQualifiedName)
+      .find(_.getClassName == taskDef.fullyQualifiedName())
       .map(_.getFileName)
       .orNull
 

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitRunner.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitRunner.scala
@@ -9,23 +9,31 @@ import munit.internal.PlatformCompat
 
 final class JUnitRunner(
     val args: Array[String],
-    val remoteArgs: Array[String],
+    _remoteArgs: Array[String],
     runSettings: RunSettings,
     classLoader: ClassLoader,
     customRunners: CustomRunners
 ) extends Runner {
   PlatformCompat.setThisClassLoader(classLoader)
 
-  def tasks(taskDefs: Array[TaskDef]): Array[Task] =
+  override def remoteArgs(): Array[String] = _remoteArgs
+
+  override def tasks(taskDefs: Array[TaskDef]): Array[Task] =
     taskDefs.map(new JUnitTask(_, runSettings, classLoader))
 
-  def done(): String = ""
+  override def done(): String = ""
 
-  def serializeTask(task: Task, serializer: TaskDef => String): String =
-    serializer(task.taskDef)
+  override def serializeTask(
+      task: Task,
+      serializer: TaskDef => String
+  ): String =
+    serializer(task.taskDef())
 
-  def deserializeTask(task: String, deserializer: String => TaskDef): Task =
+  override def deserializeTask(
+      task: String,
+      deserializer: String => TaskDef
+  ): Task =
     new JUnitTask(deserializer(task), runSettings, classLoader)
 
-  def receiveMessage(msg: String): Option[String] = None
+  override def receiveMessage(msg: String): Option[String] = None
 }

--- a/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitTask.scala
+++ b/munit/non-jvm/src/main/scala/munit/internal/junitinterface/JUnitTask.scala
@@ -16,12 +16,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
  * under the hood and stay consistent with JVM JUnit.
  */
 final class JUnitTask(
-    val taskDef: TaskDef,
+    _taskDef: TaskDef,
     runSettings: RunSettings,
     classLoader: ClassLoader
 ) extends Task {
 
-  def tags: Array[String] = Array.empty
+  override def taskDef(): TaskDef = _taskDef
+  override def tags(): Array[String] = Array.empty
 
   def execute(
       eventHandler: EventHandler,
@@ -36,12 +37,12 @@ final class JUnitTask(
       loggers: Array[Logger],
       continuation: Array[Task] => Unit
   ): Unit = {
-    PlatformCompat.newRunner(taskDef, classLoader) match {
+    PlatformCompat.newRunner(taskDef(), classLoader) match {
       case None =>
       case Some(runner) =>
         runner.filter(runSettings.tags)
         val reporter =
-          new JUnitReporter(eventHandler, loggers, runSettings, taskDef)
+          new JUnitReporter(eventHandler, loggers, runSettings, taskDef())
         val notifier: RunNotifier = new MUnitRunNotifier(reporter)
         runner.runAsync(notifier).foreach(_ => continuation(Array()))
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,8 +5,8 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.6.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.4")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
 
 libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "1.115.0"

--- a/tests/shared/src/main/scala/munit/ScalaCheckExceptionFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckExceptionFrameworkSuite.scala
@@ -52,12 +52,12 @@ class ScalaCheckExceptionFrameworkSuites
       tags = Set(OnlyJVM),
       onEvent = { event =>
         if (
-          event.throwable.isDefined &&
-          event.throwable().get.getCause() != null
+          event.throwable().isDefined() &&
+          event.throwable().get().getCause() != null
         ) {
           event
             .throwable()
-            .get
+            .get()
             .getCause
             .getStackTrace()
             .take(2)

--- a/tests/shared/src/test/scala/munit/BaseFrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/BaseFrameworkSuite.scala
@@ -82,8 +82,7 @@ abstract class BaseFrameworkSuite extends BaseSuite {
         }
       }
       implicit val ec = munitExecutionContext
-      val elapsedTimePattern =
-        Pattern.compile(" \\d+\\.\\d+s$", Pattern.MULTILINE)
+      val elapsedTimePattern = Pattern.compile(" \\d+\\.\\d+s$")
       TestingConsole.out = out
       TestingConsole.err = out
       for {

--- a/tests/shared/src/test/scala/munit/BaseFrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/BaseFrameworkSuite.scala
@@ -82,7 +82,8 @@ abstract class BaseFrameworkSuite extends BaseSuite {
         }
       }
       implicit val ec = munitExecutionContext
-      val elapsedTimePattern = Pattern.compile(" \\d+\\.\\d+s$")
+      val elapsedTimePattern =
+        Pattern.compile(" \\d+\\.\\d+s$", Pattern.MULTILINE)
       TestingConsole.out = out
       TestingConsole.err = out
       for {

--- a/tests/shared/src/test/scala/munit/BaseFrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/BaseFrameworkSuite.scala
@@ -82,8 +82,7 @@ abstract class BaseFrameworkSuite extends BaseSuite {
         }
       }
       implicit val ec = munitExecutionContext
-      val elapsedTimePattern =
-        Pattern.compile(" \\d+\\.\\d+s$", Pattern.MULTILINE)
+      val elapsedTimePattern = Pattern.compile(" \\d+\\.\\d+s ?")
       TestingConsole.out = out
       TestingConsole.err = out
       for {

--- a/tests/shared/src/test/scala/munit/ComparisonFailExceptionSuite.scala
+++ b/tests/shared/src/test/scala/munit/ComparisonFailExceptionSuite.scala
@@ -20,11 +20,11 @@ class ComparisonFailExceptionSuite extends BaseSuite {
     // console still uses `munitPrint()`, which would have displayed `List("1",
     // "2", "3")` instead of `List(1, 2, 3)`.
     assertNoDiff(
-      e.getActual,
+      e.getActual(),
       "List(1, 2, 3)"
     )
     assertNoDiff(
-      e.getExpected,
+      e.getExpected(),
       "List(1, 2)"
     )
     assertEquals(e.expected, List(1, 2))


### PR DESCRIPTION
Supersedes/backports (?) https://github.com/scalameta/munit/pull/477.

This PR is based against https://github.com/scalameta/munit/commit/92f3ad9e8261b4c142a551baaf61ef5fed84d36a aka v0.7.29. This is so that these changes can be released as 0.7.30, instead of a milestone of 1.0.0 which the ecosystem has not yet adopted.

Since there are conflicts with subsequent changes on `main`, I'll need a `series/0.7` branch to target this to.