### PR TITLE
Update Scala213 to 2.13.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import sbtcrossproject.CrossPlugin.autoImport.CrossType
 import scala.collection.mutable
 def previousVersion = "0.7.0"
-def scala213 = "2.13.6"
+def scala213 = "2.13.8"
 def scala212 = "2.12.15"
 def scala211 = "2.11.12"
 def scala3 = "3.1.1"


### PR DESCRIPTION
Updates

    org.scala-lang:scala-library
    org.scala-lang:scala-reflect

from 2.13.6 to 2.13.8.

Supersedes https://github.com/scalameta/munit/pull/481 instead of rebasing it 