### PR TITLE
Update scalafmt to 3.5.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,8 +1,14 @@
-version = "2.7.5"
+version = "3.5.1"
+
 assumeStandardLibraryStripMargin = true
-docstrings = JavaDoc
+
+// Docstring wrapping breaks doctests
+docstrings.wrap = false
+docstrings.style = Asterisk
+
 project.git=true
 project.excludeFilters = [
   ".*scala-3*"
   "LinesSuite.scala"
 ]
+runner.dialect = scala212

--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -70,11 +70,12 @@ trait ScalaCheckSuite extends FunSuite {
       if (r.passed) {
         resultMessage
       } else {
-        val seedMessage = s"""|Failing seed: ${initialSeed.toBase64}
-                              |You can reproduce this failure by adding the following override to your suite:
-                              |
-                              |  override val scalaCheckInitialSeed = "${initialSeed.toBase64}"
-                              |""".stripMargin
+        val seedMessage =
+          s"""|Failing seed: ${initialSeed.toBase64}
+              |You can reproduce this failure by adding the following override to your suite:
+              |
+              |  override val scalaCheckInitialSeed = "${initialSeed.toBase64}"
+              |""".stripMargin
         seedMessage + "\n" + resultMessage
       }
     }

--- a/munit/shared/src/main/scala/munit/Location.scala
+++ b/munit/shared/src/main/scala/munit/Location.scala
@@ -29,7 +29,7 @@ final class Location(
     obj.asInstanceOf[AnyRef].eq(this) || (obj match {
       case l: Location =>
         l.path == path &&
-          l.line == line
+        l.line == line
       case _ =>
         false
     })


### PR DESCRIPTION
This PR updates scalafmt from 2.7.5 to 3.5.1

I have tried to set things up to have a minimal diff from the previous settings but two minor changes still exist.