### PR TITLE
Format scala-3 MacroCompat with scala3 runner

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,7 +8,7 @@ docstrings.style = Asterisk
 
 project.git=true
 project.excludeFilters = [
-  ".*scala-3*"
   "LinesSuite.scala"
+  ".*scala-3.*MacroCompat.scala$"
 ]
 runner.dialect = scala212

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,6 +9,10 @@ docstrings.style = Asterisk
 project.git=true
 project.excludeFilters = [
   "LinesSuite.scala"
-  ".*scala-3.*MacroCompat.scala$"
 ]
 runner.dialect = scala212
+fileOverride {
+  "glob:**/src/{main,test}/scala-3/**" {
+    runner.dialect = scala3
+  }
+}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.5.1"
+version = "3.5.2"
 
 assumeStandardLibraryStripMargin = true
 

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.5.3"
+version = "3.5.4"
 
 assumeStandardLibraryStripMargin = true
 

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.5.2"
+version = "3.5.3"
 
 assumeStandardLibraryStripMargin = true
 

--- a/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
@@ -15,17 +15,21 @@ object MacroCompat {
   def locationImpl(c: Context): c.Tree = MacroCompatScala2.locationImpl(c)
 
   trait ClueMacro {
-    implicit def generate[T](value: T): Clue[T] = macro MacroCompatScala2.clueImpl
+    implicit def generate[T](value: T): Clue[T] =
+      macro MacroCompatScala2.clueImpl
   }
 
   @deprecated("Use MacroCompatScala2.clueImpl instead", "2020-01-06")
-  def clueImpl(c: Context)(value: c.Tree): c.Tree = MacroCompatScala2.clueImpl(c)(value)
+  def clueImpl(c: Context)(value: c.Tree): c.Tree =
+    MacroCompatScala2.clueImpl(c)(value)
 
   trait CompileErrorMacro {
-    def compileErrors(code: String): String = macro MacroCompatScala2.compileErrorsImpl
+    def compileErrors(code: String): String =
+      macro MacroCompatScala2.compileErrorsImpl
   }
 
   @deprecated("Use MacroCompatScala2.compileErrorsImpl instead", "2020-01-06")
-  def compileErrorsImpl(c: Context)(value: c.Tree): c.Tree = MacroCompatScala2.compileErrorsImpl(c)(value)
+  def compileErrorsImpl(c: Context)(value: c.Tree): c.Tree =
+    MacroCompatScala2.compileErrorsImpl(c)(value)
 
 }

--- a/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
@@ -17,36 +17,41 @@ object MacroCompat {
     val pos = Position.ofMacroExpansion
     val path = pos.sourceFile.jpath.toString
     val startLine = pos.startLine + 1
-    '{ new Location(${Expr(path)}, ${Expr(startLine)}) }
+    '{ new Location(${ Expr(path) }, ${ Expr(startLine) }) }
   }
 
   trait ClueMacro {
     inline implicit def generate[T](value: T): Clue[T] = ${ clueImpl('value) }
-    implicit def generate[T](value: T): Clue[T] = macro MacroCompatScala2.clueImpl
+    implicit def generate[T](value: T): Clue[T] =
+      macro MacroCompatScala2.clueImpl
   }
 
   def clueImpl[T: Type](value: Expr[T])(using Quotes): Expr[Clue[T]] = {
     import quotes.reflect._
     val source = value.asTerm.pos.sourceCode.getOrElse("")
     val valueType = TypeTree.of[T].show(using Printer.TreeShortCode)
-    '{ new Clue(${Expr(source)}, $value, ${Expr(valueType)}) }
+    '{ new Clue(${ Expr(source) }, $value, ${ Expr(valueType) }) }
   }
-
 
   trait CompileErrorMacro {
     inline def compileErrors(inline code: String): String = {
       val errors = scala.compiletime.testing.typeCheckErrors(code)
-      errors.map { error =>
-        val indent = " " * (error.column - 1)
-        val trimMessage = error.message.linesIterator.map { line =>
-          if (line.matches(" +")) ""
-          else line
-        }.mkString("\n")
-        val separator = if (error.message.contains('\n')) "\n" else " "
-        s"error:${separator}${trimMessage}\n${error.lineContent}\n${indent}^"
-      }.mkString("\n")
+      errors
+        .map { error =>
+          val indent = " " * (error.column - 1)
+          val trimMessage = error.message.linesIterator
+            .map { line =>
+              if (line.matches(" +")) ""
+              else line
+            }
+            .mkString("\n")
+          val separator = if (error.message.contains('\n')) "\n" else " "
+          s"error:${separator}${trimMessage}\n${error.lineContent}\n${indent}^"
+        }
+        .mkString("\n")
     }
-    def compileErrors(code: String): String = macro MacroCompatScala2.compileErrorsImpl
+    def compileErrors(code: String): String =
+      macro MacroCompatScala2.compileErrorsImpl
   }
 
 }

--- a/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
@@ -22,8 +22,8 @@ object MacroCompat {
 
   trait ClueMacro {
     inline implicit def generate[T](value: T): Clue[T] = ${ clueImpl('value) }
-    implicit def generate[T](value: T): Clue[T] =
-      macro MacroCompatScala2.clueImpl
+    implicit def generate[T](value: T): Clue[T] = macro
+      MacroCompatScala2.clueImpl
   }
 
   def clueImpl[T: Type](value: Expr[T])(using Quotes): Expr[Clue[T]] = {
@@ -50,8 +50,8 @@ object MacroCompat {
         }
         .mkString("\n")
     }
-    def compileErrors(code: String): String =
-      macro MacroCompatScala2.compileErrorsImpl
+    def compileErrors(code: String): String = macro
+      MacroCompatScala2.compileErrorsImpl
   }
 
 }


### PR DESCRIPTION
This was originally in https://github.com/scalameta/munit/pull/225 which I am trying to minimize by plucking things out of it.

This PR updates scalafmt to the latest "3.5.4", and formats the scala-3 MacroCompat files which were previously excluded.
Additionally, this formats `munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala` as the previous regex actually matches on `scala-`