### PR TITLE
Add assertCompile

### DIFF
--- a/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
@@ -1,9 +1,9 @@
 package munit.internal
 
-import munit.Clue
-import munit.Location
+import munit.{Clue, Location}
+
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox.Context
+import scala.reflect.macros.blackbox
 
 object MacroCompat {
 
@@ -12,7 +12,8 @@ object MacroCompat {
   }
 
   @deprecated("Use MacroCompatScala2.locationImpl instead", "2020-01-06")
-  def locationImpl(c: Context): c.Tree = MacroCompatScala2.locationImpl(c)
+  def locationImpl(c: blackbox.Context): c.Tree =
+    MacroCompatScala2.locationImpl(c)
 
   trait ClueMacro {
     implicit def generate[T](value: T): Clue[T] =
@@ -20,7 +21,7 @@ object MacroCompat {
   }
 
   @deprecated("Use MacroCompatScala2.clueImpl instead", "2020-01-06")
-  def clueImpl(c: Context)(value: c.Tree): c.Tree =
+  def clueImpl(c: blackbox.Context)(value: c.Tree): c.Tree =
     MacroCompatScala2.clueImpl(c)(value)
 
   trait CompileErrorMacro {
@@ -29,7 +30,7 @@ object MacroCompat {
   }
 
   @deprecated("Use MacroCompatScala2.compileErrorsImpl instead", "2020-01-06")
-  def compileErrorsImpl(c: Context)(value: c.Tree): c.Tree =
-    MacroCompatScala2.compileErrorsImpl(c)(value)
+  def compileErrorsImpl(c: blackbox.Context)(value: c.Tree): c.Tree =
+    MacroCompatScala2.compileErrorsImpl(c)(c.Expr[String](value)).tree
 
 }

--- a/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
@@ -27,6 +27,16 @@ object MacroCompat {
   trait CompileErrorMacro {
     def compileErrors(code: String): String =
       macro MacroCompatScala2.compileErrorsImpl
+
+    def assertCompile(code: String)(implicit
+        loc: Location
+    ): Unit =
+      macro MacroCompatScala2.assertCompileWithDefaultClueImpl
+
+    def assertCompile(code: String, clue: => Any)(implicit
+        loc: Location
+    ): Unit =
+      macro MacroCompatScala2.assertCompileImpl
   }
 
   @deprecated("Use MacroCompatScala2.compileErrorsImpl instead", "2020-01-06")

--- a/munit/shared/src/main/scala/munit/internal/MacroCompatScala2.scala
+++ b/munit/shared/src/main/scala/munit/internal/MacroCompatScala2.scala
@@ -1,21 +1,21 @@
 package munit.internal
 
-import munit.Clue
-import munit.Location
-import scala.reflect.macros.blackbox.Context
-import scala.reflect.macros.TypecheckException
-import scala.reflect.macros.ParseException
+import munit.{Clue, Location}
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.reflect.macros.{blackbox, ParseException, TypecheckException}
 
 object MacroCompatScala2 {
 
-  def locationImpl(c: Context): c.Tree = {
+  def locationImpl(c: blackbox.Context): c.Tree = {
     import c.universe._
     val line = Literal(Constant(c.enclosingPosition.line))
     val path = Literal(Constant(c.enclosingPosition.source.path))
-    New(c.mirror.staticClass(classOf[Location].getName()), path, line)
+    New(c.mirror.staticClass(classOf[Location].getName), path, line)
   }
 
-  def clueImpl(c: Context)(value: c.Tree): c.Tree = {
+  def clueImpl(c: blackbox.Context)(value: c.Tree): c.Tree = {
     import c.universe._
     val text: String =
       if (value.pos != null && value.pos.isRange) {
@@ -34,6 +34,8 @@ object MacroCompatScala2 {
       } else {
         ""
       }
+
+    @tailrec
     def simplifyType(tpe: Type): Type = tpe match {
       case TypeRef(ThisType(pre), sym, args) if pre == sym.owner =>
         simplifyType(c.internal.typeRef(NoPrefix, sym, args))
@@ -43,11 +45,11 @@ object MacroCompatScala2 {
         t.widen
     }
     val source = Literal(Constant(text))
-    val valueType = Literal(Constant(simplifyType(value.tpe).toString()))
+    val valueType = Literal(Constant(simplifyType(value.tpe).toString))
     New(
       c.internal.typeRef(
         NoPrefix,
-        c.mirror.staticClass(classOf[Clue[_]].getName()),
+        c.mirror.staticClass(classOf[Clue[_]].getName),
         List(value.tpe.widen)
       ),
       source,
@@ -60,21 +62,24 @@ object MacroCompatScala2 {
     import c.universe._
     val toParse: String = code match {
       case Literal(Constant(literal: String)) => literal
-      case _ =>
+      case tree =>
         c.abort(
-          code.pos,
+          tree.pos,
           "cannot compile dynamic expressions, only constant literals.\n" +
             "To fix this problem, pass in a string literal in double quotes \"...\""
         )
     }
 
-    def formatError(message: String, pos: scala.reflect.api.Position): String =
-      new StringBuilder()
+    def formatError(
+        message: String,
+        pos: scala.reflect.api.Position
+    ): String =
+      new mutable.StringBuilder()
         .append("error:")
         .append(if (message.contains('\n')) "\n" else " ")
         .append(message)
         .append("\n")
-        .append(pos.lineContent)
+        .append(pos.source.lineToString(pos.source.offsetToLine(pos.point)))
         .append("\n")
         .append(" " * (pos.column - 1))
         .append("^")
@@ -86,10 +91,11 @@ object MacroCompatScala2 {
         ""
       } catch {
         case e: ParseException =>
-          formatError(e.getMessage(), e.pos)
+          formatError(e.getMessage, e.pos)
         case e: TypecheckException =>
-          formatError(e.getMessage(), e.pos)
+          formatError(e.getMessage, e.pos)
       }
-    Literal(Constant(message))
+
+    c.Expr(Literal(Constant(message)))
   }
 }

--- a/tests/shared/src/test/scala/munit/AssertionsSuite.scala
+++ b/tests/shared/src/test/scala/munit/AssertionsSuite.scala
@@ -231,4 +231,25 @@ assertEquals(new A, new B)
     )
   }
 
+  test("code compile") {
+    assertCompile("val a: Int = 10")
+  }
+
+  test("code doesn't compile") {
+    val e: FailException = intercept[FailException] {
+      assertCompile("val a: Int = \"10\"")
+    }
+    assert(
+      clue(e).getMessage.contains(
+        """
+          |code does not compile
+          |
+          |error:
+          |type mismatch;
+          | found   : String("10")
+          | required: Int
+          |val a: Int = "10"""".stripMargin
+      )
+    )
+  }
 }

--- a/tests/shared/src/test/scala/munit/AssertionsSuite.scala
+++ b/tests/shared/src/test/scala/munit/AssertionsSuite.scala
@@ -179,6 +179,7 @@ assertEquals(new A, new B)
            |""".stripMargin
     )
   }
+
   test("array-sameElements") {
     val e = intercept[ComparisonFailException] {
       assertEquals(Array(1, 2), Array(1, 2))


### PR DESCRIPTION
Hi, since I needed several times to check if the code just compiles without worrying about the errors I thought that having `assertCompile` assertion would be useful. 🤔 

In this PR I've tried to define a macro to provide `assertCompile` based on `compileErrors`. 

So you can write an assertion like this: 
```scala
assertCompile("val a: Int = 10")
```

Open points: 
- I've put the tests inside `AssertionsSuite`, is this fine for you? 
- There are a couple of unused methods inside `MacroCompat` deprecated in the 2020, can we drop them ? 
--- 

In the meanwhile I did a super small refactoring:
- Replace `pos.lineContent` since it has been deprecated 
- Make `blackbox` macro types explicit in the signatures
- Remove unnecessaries `()` in some method calls 