### PR TITLE
Add support for JSDOM to JSIO

### DIFF
--- a/munit/js/src/main/scala/munit/internal/io/JSIO.scala
+++ b/munit/js/src/main/scala/munit/internal/io/JSIO.scala
@@ -6,7 +6,11 @@ import scala.util.Try
 object JSIO {
 
   private def require(module: String): Option[js.Dynamic] = {
-    Try(js.Dynamic.global.require(module)).toOption
+    Try(js.Dynamic.global.require(module)) // Node.js
+      .orElse( // JSDOM
+        Try(js.Dynamic.global.Node.constructor("return require")()(module))
+      )
+      .toOption
   }
   val process: Option[js.Dynamic] = require("process")
   val path: Option[js.Dynamic] = require("path")


### PR DESCRIPTION
The JSDOM JSEnv runs in a sandbox within Node.js, so it has access to the same APIs via a sandbox-breaking technique. See:
- https://github.com/jsdom/jsdom/issues/2729
- https://github.com/scala-js/scala-js-macrotask-executor/pull/17
- https://github.com/scoverage/scalac-scoverage-plugin/pull/456