### PR TITLE
scalafix 0.10.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,11 +41,11 @@ mimaPreviousArtifacts := Set.empty
 crossScalaVersions := List()
 addCommandAlias(
   "scalafixAll",
-  "; ++2.12.10 ; scalafixEnable ; all scalafix test:scalafix"
+  s"; ++$scala212 ; scalafixEnable ; all scalafix test:scalafix"
 )
 addCommandAlias(
   "scalafixCheckAll",
-  "; ++2.12.10 ;  scalafixEnable ; scalafix --check ; test:scalafix --check"
+  s"; ++$scala212 ;  scalafixEnable ; scalafix --check ; test:scalafix --check"
 )
 val isPreScala213 = Set[Option[(Long, Long)]](Some((2, 11)), Some((2, 12)))
 val scala2Versions = List(scala213, scala212, scala211)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.23")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")


### PR DESCRIPTION
Closes https://github.com/scalameta/munit/pull/550
Closes https://github.com/scalameta/munit/pull/537
Follows https://github.com/scalameta/munit/pull/513#issuecomment-1095413509

As of `sbt-scalafix` 0.10.0, scala version is no longer overriden by `scalafixEnable`, so running with `++2.12.10` would result in "type nowarn is not a member of package annotation" as `nowarn` was introduced in 2.12.13 and sbt macros generate code that uses it.

```
[error] /home/runner/work/munit/munit/munit-sbt/src/main/scala/munit/sbtmunit/MUnitPlugin.scala:42:21: type nowarn is not a member of package annotation
[error]     munitBucketName := Some("munit-test-reports"),
```