### PR TITLE
Use `def` to override `scalaCheckInitialSeed`

### DIFF
--- a/docs/integrations/scalacheck.md
+++ b/docs/integrations/scalacheck.md
@@ -131,7 +131,7 @@ a suggestion on how to reproduce it:
 Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
 You can reproduce this failure by adding the following override to your suite:
 
-  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
+  override def scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
 
 ```
 
@@ -140,7 +140,7 @@ To reproduce the failure you can follow the suggestion to fix the seed:
 ```diff
  class MySuite extends ScalaCheckSuite {
 
-+  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
++  override def scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
 
    // ...
  }

--- a/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
+++ b/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala
@@ -74,7 +74,7 @@ trait ScalaCheckSuite extends FunSuite {
           s"""|Failing seed: ${initialSeed.toBase64}
               |You can reproduce this failure by adding the following override to your suite:
               |
-              |  override val scalaCheckInitialSeed = "${initialSeed.toBase64}"
+              |  override def scalaCheckInitialSeed = "${initialSeed.toBase64}"
               |""".stripMargin
         seedMessage + "\n" + resultMessage
       }

--- a/tests/shared/src/main/scala/munit/ScalaCheckExceptionFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckExceptionFrameworkSuite.scala
@@ -42,7 +42,7 @@ class ScalaCheckExceptionFrameworkSuites
          |==> failure munit.ScalaCheckExceptionFrameworkSuite.hide my stacks - Failing seed: 9WNU_CSZAQwiiPWDlHs4NWI-knIDEKCsgGqdhZgNKnB=
          |You can reproduce this failure by adding the following override to your suite:
          |
-         |  override val scalaCheckInitialSeed = "9WNU_CSZAQwiiPWDlHs4NWI-knIDEKCsgGqdhZgNKnB="
+         |  override def scalaCheckInitialSeed = "9WNU_CSZAQwiiPWDlHs4NWI-knIDEKCsgGqdhZgNKnB="
          |
          |Exception raised on property evaluation.
          |> ARG_0: 0

--- a/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/ScalaCheckFrameworkSuite.scala
@@ -59,7 +59,7 @@ object ScalaCheckFrameworkSuite
          |Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
          |You can reproduce this failure by adding the following override to your suite:
          |
-         |  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
+         |  override def scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
          |
          |Falsified after 0 passed tests.
          |> ARG_0: -1
@@ -80,7 +80,7 @@ object ScalaCheckFrameworkSuite
          |Failing seed: CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB=
          |You can reproduce this failure by adding the following override to your suite:
          |
-         |  override val scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
+         |  override def scalaCheckInitialSeed = "CTH6hXj8ViScMmsO78-k4_RytXHPK_wSJYNH2h4dCpB="
          |
          |Falsified after 0 passed tests.
          |> ARG_0: -1


### PR DESCRIPTION
Fixes https://github.com/scalameta/munit/issues/563