### PR TITLE
MUnitRunner: avoid invoking fireTestStarted if a test is skipped. 

### DIFF
--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -279,11 +279,12 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
       return Future.successful(false)
     }
 
-    notifier.fireTestStarted(description)
     if (test.tags(Ignore)) {
       notifier.fireTestIgnored(description)
       return Future.successful(false)
     }
+
+    notifier.fireTestStarted(description)
     val onError: PartialFunction[Throwable, Future[Unit]] = {
       case ex: AssumptionViolatedException =>
         trimStackTrace(ex)


### PR DESCRIPTION
This moves down `notifier.fireTestStarted(description)` to only apply when a test is NOT ignored. This will not also follow the `org.junit.runner.notification.RunNotifier` contract but also unblock people in Gradle to use their enterprise features 

I wonder if this could be added to a potential v1.0.0-M7

Here is a build scan that shows the tests working now in Gradle with this change https://scans.gradle.com/s/t2og6zyoc3nzc/tests/overview 