### PR TITLE
Handle assume(false) correctly

### DIFF
--- a/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
@@ -129,7 +129,7 @@ final class EventDispatcher extends RunListener {
   public void testIgnored(Description desc) {
     postIfFirst(
         desc,
-        new InfoEvent(desc, Status.Skipped) {
+        new InfoEvent(desc, Status.Ignored) {
           void logTo(RichLogger logger) {
             logger.warn(
                 settings.buildTestResult(Status.Ignored)

--- a/munit/native/src/main/scala/org/junit/AssumptionViolatedException.scala
+++ b/munit/native/src/main/scala/org/junit/AssumptionViolatedException.scala
@@ -1,3 +1,4 @@
 package org.junit
 
-class AssumptionViolatedException(message: String) extends RuntimeException(message)
+class AssumptionViolatedException(message: String)
+    extends RuntimeException(message)

--- a/munit/native/src/main/scala/org/junit/AssumptionViolatedException.scala
+++ b/munit/native/src/main/scala/org/junit/AssumptionViolatedException.scala
@@ -1,3 +1,3 @@
 package org.junit
 
-class AssumptionViolatedException(message: String) extends RuntimeException
+class AssumptionViolatedException(message: String) extends RuntimeException(message)

--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -288,6 +288,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
     val onError: PartialFunction[Throwable, Future[Unit]] = {
       case ex: AssumptionViolatedException =>
         trimStackTrace(ex)
+        notifier.fireTestAssumptionFailed(new Failure(description, ex))
         Future.successful(())
       case NonFatal(ex) =>
         trimStackTrace(ex)

--- a/tests/shared/src/main/scala/munit/SkippedFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/SkippedFrameworkSuite.scala
@@ -20,7 +20,7 @@ object SkippedFrameworkSuite
     extends FrameworkTest(
       classOf[SkippedFrameworkSuite],
       """|==> success munit.SkippedFrameworkSuite.pass
-         |==> skipped munit.SkippedFrameworkSuite.ignore
+         |==> ignored munit.SkippedFrameworkSuite.ignore
          |==> success munit.SkippedFrameworkSuite.assume(true)
          |==> skipped munit.SkippedFrameworkSuite.assume(false) - assume it fails
          |""".stripMargin

--- a/tests/shared/src/main/scala/munit/SkippedFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/SkippedFrameworkSuite.scala
@@ -1,0 +1,27 @@
+package munit
+
+class SkippedFrameworkSuite extends FunSuite {
+  test("pass") {
+    // println("pass")
+  }
+  test("ignore".ignore) {
+    ???
+  }
+  test("assume(true)") {
+    assume(true, "assume it passes")
+    // println("pass")
+  }
+  test("assume(false)") {
+    assume(false, "assume it fails")
+  }
+}
+
+object SkippedFrameworkSuite
+    extends FrameworkTest(
+      classOf[SkippedFrameworkSuite],
+      """|==> success munit.SkippedFrameworkSuite.pass
+         |==> skipped munit.SkippedFrameworkSuite.ignore
+         |==> success munit.SkippedFrameworkSuite.assume(true)
+         |==> skipped munit.SkippedFrameworkSuite.assume(false) - assume it fails
+         |""".stripMargin
+    )

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -31,7 +31,8 @@ class FrameworkSuite extends BaseFrameworkSuite {
     Issue285FrameworkSuite,
     Issue497FrameworkSuite,
     ScalaCheckExceptionFrameworkSuite,
-    BoxedFrameworkSuite
+    BoxedFrameworkSuite,
+    SkippedFrameworkSuite
   )
   tests.foreach { t => check(t) }
 }


### PR DESCRIPTION
`assume(false)` gets now handled in the same way as `test("description".ignore")`. Added tests to cover both ways to skip tests.

Fixes #614