### PR TITLE
feat(printer): mk printers more easily configurable

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -134,7 +134,7 @@ import java.time.Instant
 import munit.FunSuite
 import munit.Printer
 
-class InstantTest extends FunSuite {
+class CompareDatesOnlyTest extends FunSuite {
   override val printer = Printer.apply {
     // take only the date part of the Instant
     case instant: Instant => instant.toString.takeWhile(_ != 'T')
@@ -154,12 +154,12 @@ or to customize the printed clue in case of a failure :
 import munit.FunSuite
 import munit.Printer
 
-class InstantTest extends munit.FunSuite {
+class CustomListOfCharPrinterTest extends FunSuite {
   override val printer = Printer.apply {
     case l: List[Char] => l.mkString
   }
 
-  test("dates only") {
+  test("lists of chars") {
     val expected = List('h', 'e', 'l', 'l', 'o')
     val actual = List('h', 'e', 'l', 'l', '0')
     assertEquals(actual, expected)

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -120,6 +120,82 @@ class CustomTimeoutSuite extends munit.FunSuite {
 > non-async tests. However, starting with MUnit v1.0 (latest milestone release:
 > @VERSION@), the timeout applies to all tests including non-async tests.
 
+## Customize value printers
+
+MUnit uses its own `Printer`s to convert any value into a diff-ready string representation.
+The resulting string is the actual value being compared, and is also used to generate the clues in case of a failure.
+
+The default printing behaviour can be overriden for a given type by defining a custom `Printer` and overriding `printer`.
+
+Override `printer` to customize the comparison of two values :
+
+```scala mdoc
+import java.time.Instant
+import munit.FunSuite
+import munit.Printer
+
+class InstantTest extends FunSuite {
+  override val printer = Printer.apply {
+    // take only the date part of the Instant
+    case instant: Instant => instant.toString.takeWhile(_ != 'T')
+  }
+
+  test("dates only") {
+    val expected = Instant.parse("2022-02-15T18:35:24.00Z")
+    val actual = Instant.parse("2022-02-15T18:36:01.00Z")
+    assertEquals(actual, expected) // true
+  }
+}
+```
+
+or to customize the printed clue in case of a failure :
+
+```scala mdoc
+import munit.FunSuite
+import munit.Printer
+
+class InstantTest extends munit.FunSuite {
+  override val printer = Printer.apply {
+    case l: List[Char] => l.mkString
+  }
+
+  test("dates only") {
+    val expected = List('h', 'e', 'l', 'l', 'o')
+    val actual = List('h', 'e', 'l', 'l', '0')
+    assertEquals(actual, expected)
+  }
+}
+```
+
+will yield
+
+```
+=> Obtained
+hell0
+=> Diff (- obtained, + expected)
+-hell0
++hello
+```
+
+instead of the default
+
+```
+...
+=> Obtained
+List(
+  'h',
+  'e',
+  'l',
+  'l',
+  '0'
+)
+=> Diff (- obtained, + expected)
+   'l',
+-  '0'
++  'o'
+...
+```
+
 ## Run tests in parallel
 
 MUnit does not support running individual test cases in parallel. However, sbt
@@ -140,7 +216,7 @@ Test / testOptions += Tests.Argument(TestFrameworks.MUnit, "-b")
 ```
 
 To learn more about sbt test execution, see
-https://www.scala-sbt.org/1.x/docs/Testing.html.
+<https://www.scala-sbt.org/1.x/docs/Testing.html>.
 
 ## Declare tests inside a helper function
 

--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -303,10 +303,12 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
   }
   def clues(clue: Clue[_]*): Clues = new Clues(clue.toList)
 
+  def printer: Printer = EmptyPrinter
+
   def munitPrint(clue: => Any): String = {
     clue match {
       case message: String => message
-      case value           => Printers.print(value)
+      case value           => Printers.print(value, printer)
     }
   }
 

--- a/munit/shared/src/main/scala/munit/Printer.scala
+++ b/munit/shared/src/main/scala/munit/Printer.scala
@@ -14,6 +14,78 @@ trait Printer {
   def height: Int = 100
   def isMultiline(string: String): Boolean =
     string.contains('\n')
+
+  /**
+   * Combine two printers into a single printer.
+   *
+   * Order is important : this printer will be tried first, then the other printer.
+   * The new Printer's height will be the max of the two printers' heights.
+   * 
+   * Comibining two printers can be useful if you want to customize Printer for
+   * some types somewhere, but want to add more specialized printers for some tests 
+   * 
+   * {{{
+   * trait MySuites extends FunSuite { 
+   *   override val printer = Printer { 
+   *     case long => s"${l}L"
+   *   }
+   * }
+   * 
+   * trait SomeOtherSuites extends MySuites {
+   *   override val printer = Printer {
+   *     case m: SomeCaseClass => m.someCustomToString
+   *   } orElse super.printer
+   * }
+   * 
+   * }}}
+   */
+  def orElse(other: Printer): Printer =
+    new Printer {
+      def print(value: Any, out: StringBuilder, indent: Int): Boolean =
+        this.print(value, out, indent) || other.print(
+          value,
+          out,
+          indent
+        )
+      override def height: Int = this.height.max(other.height)
+    }
+
+  val a = Byte
+}
+
+object Printer {
+
+  def apply(h: Int)(partialPrint: PartialFunction[Any, String]): Printer =
+    new Printer {
+      def print(value: Any, out: StringBuilder, indent: Int): Boolean =
+        value match {
+          case simpleValue =>
+            partialPrint.lift.apply(simpleValue).fold(false) { string =>
+              out.append(string)
+              true
+            }
+        }
+
+      override def height: Int = h
+    }
+
+  /**
+   * Utiliy constructor defining a printer for some types.
+   *
+   * This might be useful for some types which default pretty-printers
+   * do not output helpful diffs.
+   *
+   * {{{
+   * type ByteArray = Array[Byte]
+   * val listPrinter = Printer {
+   *   case ll: ByteArray => ll.map(String.format("%02x", b)).mkString(" ")
+   * }
+   * val bytes = Array[Byte](1, 5, 8, 24)
+   * Printers.print(bytes, listPrinter) // "01 05 08 18"
+   * }}}
+   */
+  def apply(partialPrint: PartialFunction[Any, String]): Printer =
+    apply(100)(partialPrint)
 }
 
 /** Default printer that does not customize the pretty-printer */

--- a/munit/shared/src/main/scala/munit/Printer.scala
+++ b/munit/shared/src/main/scala/munit/Printer.scala
@@ -21,13 +21,13 @@ trait Printer {
    * Order is important : this printer will be tried first, then the other printer.
    * The new Printer's height will be the max of the two printers' heights.
    *
-   * Exampple use case :  define some default printers for some types for all tests,
+   * Example use case :  define some default printers for some types for all tests,
    * and override it for some tests only.
    *
    * {{{
-   *  
+   *
    * case class Person(name: String, age: Int, mail: String)
-   *  
+   *
    * trait MySuites extends FunSuite {
    *   override val printer = Printer.apply {
    *     case Person(name, age, mail) => s"$name:$age:$mail"
@@ -105,4 +105,3 @@ object Printer {
 object EmptyPrinter extends Printer {
   def print(value: Any, out: StringBuilder, indent: Int): Boolean = false
 }
-  

--- a/tests/shared/src/test/scala/munit/CustomPrinterSuite.scala
+++ b/tests/shared/src/test/scala/munit/CustomPrinterSuite.scala
@@ -1,0 +1,131 @@
+package munit
+
+import org.scalacheck.Prop.forAll
+import munit.internal.console.Printers
+import org.scalacheck.Arbitrary.arbitrary
+import scala.collection.immutable
+
+class CustomPrinterSuite extends FunSuite with ScalaCheckSuite {
+
+  private case class Foo(i: Int)
+
+  private case class Bar(is: List[Int])
+
+  private case class FooBar(foo: Foo, bar: Bar)
+
+  private val genFoo = arbitrary[Int].map(Foo(_))
+
+  private val genBar = arbitrary[List[Int]].map(Bar(_))
+
+  private val genFooBar = for {
+    foo <- genFoo
+    bar <- genBar
+  } yield FooBar(foo, bar)
+
+  private val longPrinter = Printer { case l: Long =>
+    s"MoreThanInt($l)"
+  }
+
+  private val fooPrinter = Printer { case Foo(i) =>
+    s"Foo(INT($i))"
+  }
+
+  private val listPrinter = Printer { case l: List[_] =>
+    l.mkString("[", ",", "]")
+  }
+
+  private val intPrinter = Printer { case i: Int =>
+    s"NotNaN($i)"
+  }
+
+  property("long") {
+    forAll(arbitrary[Long]) { (l: Long) =>
+      val obtained = Printers.print(l, longPrinter)
+      val expected = s"MoreThanInt($l)"
+      assertEquals(obtained, expected)
+    }
+  }
+
+  property("list") {
+    forAll(arbitrary[List[Int]]) { l =>
+      val obtained = Printers.print(l, listPrinter)
+      val expected = l.mkString("[", ",", "]")
+      assertEquals(obtained, expected)
+    }
+  }
+
+  property("product") {
+    forAll(arbitrary[Int]) { i =>
+      val input = Foo(i)
+      val obtained = Printers.print(input, fooPrinter)
+      val expected = s"Foo(INT($i))"
+      assertEquals(obtained, expected)
+    }
+  }
+
+  property("int in product") {
+    forAll(arbitrary[Int]) { i =>
+      val input = Foo(i)
+      val obtained = Printers.print(input, intPrinter)
+      val expected = s"Foo(\n  i = NotNaN($i)\n)"
+      assertEquals(obtained, expected)
+    }
+  }
+
+  property("list in product") {
+    forAll(arbitrary[List[Int]]) { l =>
+      val input = Bar(l)
+      val obtained = Printers.print(input, listPrinter)
+      val expected = s"Bar(\n  is = ${l.mkString("[", ",", "]")}\n)"
+      assertEquals(obtained, expected)
+    }
+  }
+
+  property("list and int in product") {
+    forAll(genFooBar) { foobar =>
+      val obtained = Printers
+        .print(foobar, listPrinter.orElse(intPrinter))
+        .stripMargin
+        .stripLeading()
+        .stripTrailing()
+      val expected =
+        s"""|FooBar(
+            |  foo = Foo(
+            |    i = NotNaN(${foobar.foo.i})
+            |  ),
+            |  bar = Bar(
+            |    is = ${foobar.bar.is.mkString("[", ",", "]")}
+            |  )
+            |)
+            |""".stripMargin.stripLeading().stripTrailing()
+      assertEquals(obtained, expected)
+    }
+  }
+
+  property("all ints in product") {
+    forAll(genFooBar) { foobar =>
+      val obtained = Printers
+        .print(foobar, intPrinter)
+        .filterNot(_.isWhitespace)
+
+      val expectedbBarList = foobar.bar.is match {
+        case Nil => "Nil"
+        case l =>
+          l.map(i => s"NotNaN($i)").mkString("List(", ",", ")")
+      }
+
+      val expected =
+        s"""|FooBar(
+            |  foo = Foo(
+            |    i = NotNaN(${foobar.foo.i})
+            |  ),
+            |  bar = Bar(
+            |    is = $expectedbBarList
+            |  )
+            |)
+            |""".stripMargin.filterNot(_.isWhitespace)
+      assertEquals(obtained, expected)
+    }
+  }
+
+}

--- a/tests/shared/src/test/scala/munit/CustomPrinterSuite.scala
+++ b/tests/shared/src/test/scala/munit/CustomPrinterSuite.scala
@@ -3,42 +3,55 @@ package munit
 import org.scalacheck.Prop.forAll
 import munit.internal.console.Printers
 import org.scalacheck.Arbitrary.arbitrary
-import scala.collection.immutable
+import org.scalacheck.Prop
 
 class CustomPrinterSuite extends FunSuite with ScalaCheckSuite {
 
   private case class Foo(i: Int)
 
-  private case class Bar(is: List[Int])
+  private case class Bar(l: List[Int])
 
   private case class FooBar(foo: Foo, bar: Bar)
 
   private val genFoo = arbitrary[Int].map(Foo(_))
 
-  private val genBar = arbitrary[List[Int]].map(Bar(_))
+  // limit size to 10 to have a reasonable number of values
+  private val genBar = arbitrary[List[Int]].map(l => Bar(l.take(10)))
 
   private val genFooBar = for {
     foo <- genFoo
     bar <- genBar
   } yield FooBar(foo, bar)
 
-  private val longPrinter = Printer { case l: Long =>
+  private val longPrinter: Printer = Printer.apply { case l: Long =>
     s"MoreThanInt($l)"
   }
 
-  private val fooPrinter = Printer { case Foo(i) =>
+  private val fooPrinter: Printer = Printer.apply { case Foo(i) =>
     s"Foo(INT($i))"
   }
 
-  private val listPrinter = Printer { case l: List[_] =>
+  private val listPrinter: Printer = Printer.apply { case l: List[_] =>
     l.mkString("[", ",", "]")
   }
 
-  private val intPrinter = Printer { case i: Int =>
+  private val intPrinter: Printer = Printer.apply { case i: Int =>
     s"NotNaN($i)"
   }
 
-  property("long") {
+  private val isScala213: Boolean = BuildInfo.scalaVersion.startsWith("2.13")
+
+  private def checkProp(
+      options: TestOptions,
+      isEnabled: Boolean = true
+  )(p: => Prop): Unit = {
+    test(options) {
+      assume(isEnabled, "disabled test")
+      p
+    }
+  }
+
+  checkProp("long") {
     forAll(arbitrary[Long]) { (l: Long) =>
       val obtained = Printers.print(l, longPrinter)
       val expected = s"MoreThanInt($l)"
@@ -46,7 +59,7 @@ class CustomPrinterSuite extends FunSuite with ScalaCheckSuite {
     }
   }
 
-  property("list") {
+  checkProp("list") {
     forAll(arbitrary[List[Int]]) { l =>
       val obtained = Printers.print(l, listPrinter)
       val expected = l.mkString("[", ",", "]")
@@ -54,34 +67,31 @@ class CustomPrinterSuite extends FunSuite with ScalaCheckSuite {
     }
   }
 
-  property("product") {
-    forAll(arbitrary[Int]) { i =>
-      val input = Foo(i)
-      val obtained = Printers.print(input, fooPrinter)
-      val expected = s"Foo(INT($i))"
+  checkProp("product") {
+    forAll(genFoo) { foo =>
+      val obtained = Printers.print(foo, fooPrinter)
+      val expected = s"Foo(INT(${foo.i}))"
       assertEquals(obtained, expected)
     }
   }
 
-  property("int in product") {
-    forAll(arbitrary[Int]) { i =>
-      val input = Foo(i)
-      val obtained = Printers.print(input, intPrinter)
-      val expected = s"Foo(\n  i = NotNaN($i)\n)"
+  checkProp("int in product", isEnabled = isScala213) {
+    forAll(genFoo) { foo =>
+      val obtained = Printers.print(foo, intPrinter)
+      val expected = s"Foo(\n  i = NotNaN(${foo.i})\n)"
       assertEquals(obtained, expected)
     }
   }
 
-  property("list in product") {
-    forAll(arbitrary[List[Int]]) { l =>
-      val input = Bar(l)
-      val obtained = Printers.print(input, listPrinter)
-      val expected = s"Bar(\n  is = ${l.mkString("[", ",", "]")}\n)"
+  checkProp("list in product", isEnabled = isScala213) {
+    forAll(genBar) { bar =>
+      val obtained = Printers.print(bar, listPrinter)
+      val expected = s"Bar(\n  l = ${bar.l.mkString("[", ",", "]")}\n)"
       assertEquals(obtained, expected)
     }
   }
 
-  property("list and int in product") {
+  checkProp("list and int in product", isEnabled = isScala213) {
     forAll(genFooBar) { foobar =>
       val obtained = Printers
         .print(foobar, listPrinter.orElse(intPrinter))
@@ -94,7 +104,7 @@ class CustomPrinterSuite extends FunSuite with ScalaCheckSuite {
             |    i = NotNaN(${foobar.foo.i})
             |  ),
             |  bar = Bar(
-            |    is = ${foobar.bar.is.mkString("[", ",", "]")}
+            |    l = ${foobar.bar.l.mkString("[", ",", "]")}
             |  )
             |)
             |""".stripMargin.stripLeading().stripTrailing()
@@ -102,13 +112,13 @@ class CustomPrinterSuite extends FunSuite with ScalaCheckSuite {
     }
   }
 
-  property("all ints in product") {
+  checkProp("all ints in product", isEnabled = isScala213) {
     forAll(genFooBar) { foobar =>
       val obtained = Printers
         .print(foobar, intPrinter)
         .filterNot(_.isWhitespace)
 
-      val expectedbBarList = foobar.bar.is match {
+      val expectedbBarList = foobar.bar.l match {
         case Nil => "Nil"
         case l =>
           l.map(i => s"NotNaN($i)").mkString("List(", ",", ")")
@@ -120,7 +130,7 @@ class CustomPrinterSuite extends FunSuite with ScalaCheckSuite {
             |    i = NotNaN(${foobar.foo.i})
             |  ),
             |  bar = Bar(
-            |    is = $expectedbBarList
+            |    l = $expectedbBarList
             |  )
             |)
             |""".stripMargin.filterNot(_.isWhitespace)

--- a/tests/shared/src/test/scala/munit/CustomPrinterSuite.scala
+++ b/tests/shared/src/test/scala/munit/CustomPrinterSuite.scala
@@ -95,9 +95,7 @@ class CustomPrinterSuite extends FunSuite with ScalaCheckSuite {
     forAll(genFooBar) { foobar =>
       val obtained = Printers
         .print(foobar, listPrinter.orElse(intPrinter))
-        .stripMargin
-        .stripLeading()
-        .stripTrailing()
+        .filterNot(_.isWhitespace)
       val expected =
         s"""|FooBar(
             |  foo = Foo(
@@ -107,7 +105,7 @@ class CustomPrinterSuite extends FunSuite with ScalaCheckSuite {
             |    l = ${foobar.bar.l.mkString("[", ",", "]")}
             |  )
             |)
-            |""".stripMargin.stripLeading().stripTrailing()
+            |""".stripMargin.filterNot(_.isWhitespace)
       assertEquals(obtained, expected)
     }
   }


### PR DESCRIPTION
Hi ! 

Following this issue I opened https://github.com/scalameta/munit/issues/637 and closed right after once I realised I should havve looked around a bit more, I tried my hand at using custom pretty printers to clarify some of my diffs. 

Using the answer to this question https://github.com/scalameta/munit/issues/480 I got pretty much what a I needed ( comparing scodecs ByteVectors ) but I found the experience a bit confusing and felt some boilerplate could be avoided.

Which leads me to this PR :) 

Changes : 

- add `orElse` combinator for `Printer` for composability
- add utility constructor for easier instantiation : user will only pass whatever is actually meaningful to them in most cases, ie. the custom logic to turn their test values into differenciable strings
- update `Assertion` to allow users to pass their custom `Printer` without also overriding `munitPrint`