### PR TITLE
Handle a StackOverflowError in addition to NonFatal errors

### DIFF
--- a/tests/shared/src/main/scala/munit/Issue583FrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/Issue583FrameworkSuite.scala
@@ -1,0 +1,25 @@
+package munit
+
+class Issue583FrameworkSuite extends FunSuite {
+  test("simple test") {
+    ()
+  }
+  test("infinite loop test") {
+    def loop(x: Int): Int = loop(x) + loop(x)
+
+    loop(0)
+  }
+  test("another test") {
+    ()
+  }
+}
+
+object Issue583FrameworkSuite
+    extends FrameworkTest(
+      classOf[Issue583FrameworkSuite],
+      """|==> success munit.Issue583FrameworkSuite.simple test
+         |==> failure munit.Issue583FrameworkSuite.infinite loop test - null
+         |==> success munit.Issue583FrameworkSuite.another test
+         |""".stripMargin,
+      tags = Set(OnlyJVM)
+    )

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -30,6 +30,7 @@ class FrameworkSuite extends BaseFrameworkSuite {
     Issue179FrameworkSuite,
     Issue285FrameworkSuite,
     Issue497FrameworkSuite,
+    Issue583FrameworkSuite,
     ScalaCheckExceptionFrameworkSuite,
     BoxedFrameworkSuite,
     SkippedFrameworkSuite


### PR DESCRIPTION
if they are happening inside a test

I only execute the test on the JVM, because
- on JS the error message is different
- on Native the runner just terminates (I know too little about ScalaNative)

Fixes #583