### PR TITLE
feat: respect NO_COLOR env variable

### DIFF
--- a/junit-interface/src/main/java/munit/internal/junitinterface/Ansi.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/Ansi.java
@@ -23,7 +23,9 @@ public class Ansi {
   private static final String LIGHT_CYAN = "\u001B[96m";
 
   public static String c(String s, String colorSequence) {
-    if (colorSequence == null) return s;
+    String no_color = System.getenv("NO_COLOR");
+    Boolean isNoColorEnvSet = no_color != null && no_color.equals("1");
+    if (colorSequence == null || isNoColorEnvSet) return s;
     else return colorSequence + s + NORMAL;
   }
 

--- a/munit/shared/src/main/scala/munit/internal/console/AnsiColors.scala
+++ b/munit/shared/src/main/scala/munit/internal/console/AnsiColors.scala
@@ -1,23 +1,28 @@
 package munit.internal.console
 
 object AnsiColors {
-  val LightRed = "\u001b[91m"
+  // Foreground colors
+  val BLUE = "\u001B[34m"
+  val CYAN = "\u001B[36m"
+  val DarkGrey = "\u001B[90m"
+  val GREEN = "\u001B[32m"
   val LightGreen = "\u001b[92m"
-  val Reset = "\u001b[0m"
-  val Reversed = "\u001b[7m"
-  val Bold = "\u001b[1m"
-  val Faint = "\u001b[2m"
+  val LightRed = "\u001b[91m"
+  val Magenta = "\u001B[35m"
   val RED = "\u001B[31m"
   val YELLOW = "\u001B[33m"
-  val BLUE = "\u001B[34m"
-  val Magenta = "\u001B[35m"
-  val CYAN = "\u001B[36m"
-  val GREEN = "\u001B[32m"
-  val DarkGrey = "\u001B[90m"
 
-  def c(s: String, colorSequence: String): String =
-    if (colorSequence == null) s
+  // Styles
+  val Bold = "\u001b[1m"
+  val Faint = "\u001b[2m"
+  val Reset = "\u001b[0m"
+  val Reversed = "\u001b[7m"
+
+  def c(s: String, colorSequence: String): String = {
+    val isNoColorEnvSet = System.getenv("NO_COLOR") == "1"
+    if (colorSequence == null || isNoColorEnvSet) s
     else colorSequence + s + Reset
+  }
 
   def filterAnsi(s: String): String = {
     if (s == null) {

--- a/munit/shared/src/main/scala/munit/internal/console/Lines.scala
+++ b/munit/shared/src/main/scala/munit/internal/console/Lines.scala
@@ -44,10 +44,12 @@ class Lines extends Serializable {
           .append(format(location.line - 1))
           .append(slice(0))
           .append('\n')
-          .append(AnsiColors.Reversed)
-          .append(format(location.line))
-          .append(slice(1))
-          .append(AnsiColors.Reset)
+          .append(
+            AnsiColors.c(
+              s"${format(location.line)}${slice(1)}",
+              AnsiColors.Reversed
+            )
+          )
         if (slice.length >= 3)
           out
             .append('\n')

--- a/munit/shared/src/main/scala/munit/internal/difflib/Diff.scala
+++ b/munit/shared/src/main/scala/munit/internal/difflib/Diff.scala
@@ -43,9 +43,9 @@ class Diff(val obtained: String, val expected: String) extends Serializable {
 
   private def appendDiffOnlyReport(sb: StringBuilder): Unit = {
     header("Diff", sb)
-    sb.append(
-      s" (${AnsiColors.LightRed}- obtained${AnsiColors.Reset}, ${AnsiColors.LightGreen}+ expected${AnsiColors.Reset})"
-    ).append("\n")
+    val obtained = AnsiColors.c("- obtained", AnsiColors.LightRed)
+    val expected = AnsiColors.c("+ expected", AnsiColors.LightGreen)
+    sb.append(s" ($obtained, $expected)").append("\n")
     sb.append(unifiedDiff)
   }
 


### PR DESCRIPTION
Resolves https://github.com/scalameta/munit/issues/149

This PR makes use of the [NO_COLOR](http://no-color.org/) environment variable, disabling all ansi escapes when `NO_COLOR=1`.

Example:
```scala
//> using scala "2.13.10"
//> using lib "org.scalameta::munit::1.0.0-SNAPSHOT" // published locally

class MyTests extends munit.FunSuite {
  test("foo") {
    assert(2 + 2 == 4)
  }
}
```
<img src="https://user-images.githubusercontent.com/15569000/234430385-41f2870e-6a50-45d9-9908-0c4ba72f74e7.png" width="400" />