### PR TITLE
fix intercept for AssertionError

### DIFF
--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -189,14 +189,15 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
       expectedExceptionMessage: Option[String],
       body: => Any
   )(implicit T: ClassTag[T], loc: Location): T = {
+    val expectedExceptionMsg =
+      s"expected exception of type '${T.runtimeClass.getName()}' but body evaluated successfully"
     try {
       body
-      fail(
-        s"expected exception of type '${T.runtimeClass.getName()}' but body evaluated successfully"
-      )
+      fail(expectedExceptionMsg)
     } catch {
       case e: FailExceptionLike[_]
-          if !T.runtimeClass.isAssignableFrom(e.getClass()) =>
+          if !T.runtimeClass.isAssignableFrom(e.getClass()) ||
+            e.getMessage.contains(expectedExceptionMsg) =>
         throw e
       case NonFatal(e) =>
         if (T.runtimeClass.isAssignableFrom(e.getClass())) {

--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -196,8 +196,10 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
       fail(expectedExceptionMsg)
     } catch {
       case e: FailExceptionLike[_]
-          if !T.runtimeClass.isAssignableFrom(e.getClass()) ||
-            e.getMessage.contains(expectedExceptionMsg) =>
+          if !T.runtimeClass.isAssignableFrom(e.getClass()) =>
+        throw e
+      case e: FailExceptionLike[_]
+          if e.getMessage.contains(expectedExceptionMsg) =>
         throw e
       case NonFatal(e) =>
         if (T.runtimeClass.isAssignableFrom(e.getClass())) {

--- a/tests/shared/src/test/scala/munit/FailExceptionSuite.scala
+++ b/tests/shared/src/test/scala/munit/FailExceptionSuite.scala
@@ -7,4 +7,19 @@ class FailExceptionSuite extends BaseSuite {
     }
     assert(clue(e).isInstanceOf[Serializable])
   }
+
+  test("assertion-error no exception") {
+    try {
+      intercept[AssertionError] {
+        println("throwing no exception!")
+      }
+    } catch {
+      case e: FailException =>
+        assert(
+          e.getMessage.contains(
+            "expected exception of type 'java.lang.AssertionError' but body evaluated successfully"
+          )
+        )
+    }
+  }
 }

--- a/tests/shared/src/test/scala/munit/FailExceptionSuite.scala
+++ b/tests/shared/src/test/scala/munit/FailExceptionSuite.scala
@@ -8,7 +8,7 @@ class FailExceptionSuite extends BaseSuite {
     assert(clue(e).isInstanceOf[Serializable])
   }
 
-test("assertion-error-no-exception") {
+  test("assertion-error-no-exception") {
     try {
       intercept[AssertionError] {
         println("throwing no exception!")

--- a/tests/shared/src/test/scala/munit/FailExceptionSuite.scala
+++ b/tests/shared/src/test/scala/munit/FailExceptionSuite.scala
@@ -8,11 +8,12 @@ class FailExceptionSuite extends BaseSuite {
     assert(clue(e).isInstanceOf[Serializable])
   }
 
-  test("assertion-error no exception") {
+test("assertion-error-no-exception") {
     try {
       intercept[AssertionError] {
         println("throwing no exception!")
       }
+      throw new Exception("should not reach here")
     } catch {
       case e: FailException =>
         assert(
@@ -20,6 +21,8 @@ class FailExceptionSuite extends BaseSuite {
             "expected exception of type 'java.lang.AssertionError' but body evaluated successfully"
           )
         )
+      case _: Throwable =>
+        fail("No FailException was thrown")
     }
   }
 }


### PR DESCRIPTION
When trying to `intercept` an `AssertionError` till now the test passed successfully. 
This fix treats the FailException special.

closes: #679