### PR TITLE
Call `scalanative.runtime.loop()`

### DIFF
--- a/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
@@ -24,7 +24,9 @@ object PlatformCompat {
       duration: Duration,
       ec: ExecutionContext
   ): Future[T] = {
-    startFuture()
+    val f = startFuture()
+    scala.scalanative.runtime.loop()
+    f
   }
   def setTimeout(ms: Int)(body: => Unit): () => Unit = {
     Thread.sleep(ms)


### PR DESCRIPTION
I'm surprised that this was missing and nobody noticed for so long. Every other test framework does this, it's absolutely essential.

Fixes https://github.com/scalameta/munit/issues/692.