### PR TITLE
Use a package proxy for `scalanative.runtime.loop`

### DIFF
--- a/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
@@ -14,7 +14,7 @@ import scala.concurrent.ExecutionContext
 
 object PlatformCompat {
   def awaitResult[T](awaitable: Awaitable[T]): T = {
-    scalanative.runtime.loop()
+    scalanative.runtime.munit.drainExecutionContext()
     Await.result(awaitable, Duration.Inf)
   }
 

--- a/munit/native/src/main/scala/scalanative/munit/package.scala
+++ b/munit/native/src/main/scala/scalanative/munit/package.scala
@@ -1,0 +1,6 @@
+package scala.scalanative.runtime
+
+package object munit {
+  /** Drains the execution context by executing all pending tasks. */
+  def drainExecutionContext(): Unit = loop()
+}


### PR DESCRIPTION
...since it is becoming package-private from v0.5 onwards with https://github.com/scala-native/scala-native/pull/3423.
I'm not sure about it *staying* private though, as @wjcmazur mentioned about reverting it, so I'm keeping this PR as draft.
