### PR TITLE
Restore v0.7.x fixture ordering

### DIFF
--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -63,7 +63,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
       suite.afterAll()
   }
   private lazy val munitFixtures: List[AnyFixture[_]] =
-    suiteFixtureBefore :: suite.munitFixtures.appended(suiteFixtureAfter).toList
+    suiteFixtureBefore :: (suite.munitFixtures.toList ::: suiteFixtureAfter :: Nil)
 
   override def filter(filter: Filter): Unit = {
     val newTests = munitTests.filter { t =>

--- a/tests/shared/src/main/scala/munit/FixtureOrderFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/FixtureOrderFrameworkSuite.scala
@@ -53,29 +53,29 @@ object FixtureOrderFrameworkSuite
          |beforeEach(a, 1)
          |beforeEach(b, 1)
          |test(1)
-         |afterEach(ad-hoc, 1)
          |afterEach(a, 1)
          |afterEach(b, 1)
+         |afterEach(ad-hoc, 1)
          |  + 1 <elapsed time>
          |beforeEach(ad-hoc, 2)
          |beforeEach(a, 2)
          |beforeEach(b, 2)
          |test(2)
-         |afterEach(ad-hoc, 2)
          |afterEach(a, 2)
          |afterEach(b, 2)
+         |afterEach(ad-hoc, 2)
          |  + 2 <elapsed time>
          |beforeEach(ad-hoc, 3)
          |beforeEach(a, 3)
          |beforeEach(b, 3)
          |test(3)
-         |afterEach(ad-hoc, 3)
          |afterEach(a, 3)
          |afterEach(b, 3)
+         |afterEach(ad-hoc, 3)
          |  + 3 <elapsed time>
-         |afterAll(ad-hoc)
          |afterAll(a)
          |afterAll(b)
+         |afterAll(ad-hoc)
          |""".stripMargin,
       format = StdoutFormat
     )

--- a/tests/shared/src/test/scala/munit/SuiteLocalFixtureSuite.scala
+++ b/tests/shared/src/test/scala/munit/SuiteLocalFixtureSuite.scala
@@ -12,7 +12,7 @@ class SuiteLocalFixtureSuite extends FunSuite {
       n = 1
     }
     override def afterAll(): Unit = {
-      assertEquals(n, 17)
+      assertEquals(n, 16)
       n = -11
     }
   }
@@ -34,7 +34,7 @@ class SuiteLocalFixtureSuite extends FunSuite {
   }
 
   override def afterAll(): Unit = {
-    assertEquals(counter(), 17)
+    assertEquals(counter(), -10)
   }
 
   1.to(5).foreach { i =>


### PR DESCRIPTION
 :warning: **Breaking Change** :warning: 

This PR changes the ordering in which suite-local fixture `afterAll` methods are called.
It implements the trick @olafurpg describes in https://github.com/scalameta/munit/issues/573#issuecomment-1465269356 to restore the fixture ordering of v0.7.x
This ordering was changed in the [first v1.0 milestone release](https://github.com/scalameta/munit/releases/tag/v1.0.0-M1)
Therefore it is a breaking change within the v1.0 milestones in order to avoid a breaking change between v0.7.x and v1.0 overall.

Namely, we split up the suite-local fixture implementation into two fixtures, one of the `before*` methods, and one for the `after*` methods. Then we explicitly order `munitFixtures` to have the befores up front and the afters at the end.

Of particular note, the tests/shared/src/main/scala/munit/FixtureOrderFrameworkSuite.scala file now looks the same as it did before https://github.com/scalameta/munit/pull/430/files?diff=split&w=0#diff-714f7ef13dfbbd4747770936315606f95d8aeba5f24890a45a4be216cda9d8a1

Note: The v0.7.x style ordering is not to run the `after*` methods in opposite order to how the `before*` methods were run, making a mirror image like pattern. Instead it's more like `after*` methods run in the same order as `before*` methods *except* for suite-local fixtures which are special cased to run last.