### PR TITLE
chore: Don't publish the docs module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -343,6 +343,7 @@ lazy val docs = project
   .disablePlugins(MimaPlugin)
   .settings(
     sharedSettings,
+    publish / skip := true,
     moduleName := "munit-docs",
     crossScalaVersions := List(scala213, scala212),
     test := {},


### PR DESCRIPTION
I merged the update for mdoc, which uses Java 11, but that is needed to publish the website. It seems the normal release tries to publish docs and that breaks because of the mdoc JVM requirement.

This should fix the release.