### PR TITLE
improvement: Add transparent to compileErrors

### DIFF
--- a/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
@@ -34,7 +34,7 @@ object MacroCompat {
   }
 
   trait CompileErrorMacro {
-    inline def compileErrors(inline code: String): String = {
+    transparent inline def compileErrors(inline code: String): String = {
       val errors = scala.compiletime.testing.typeCheckErrors(code)
       errors
         .map { error =>


### PR DESCRIPTION
This seems to fix issues with https://github.com/scalameta/munit/issues/711