### PR TITLE
chore: Remove deprecated methods before 1.0.0

### DIFF
--- a/munit/jvm/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/jvm/src/main/scala/munit/internal/PlatformCompat.scala
@@ -43,13 +43,7 @@ object PlatformCompat {
     task.execute(eventHandler, loggers)
     Future.successful(())
   }
-  @deprecated("use the overload with an explicit ExecutionContext", "1.0.0")
-  def waitAtMost[T](
-      future: Future[T],
-      duration: Duration
-  ): Future[T] = {
-    waitAtMost(() => future, duration, ExecutionContext.global)
-  }
+
   def waitAtMost[T](
       startFuture: () => Future[T],
       duration: Duration,

--- a/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-2/munit/internal/MacroCompat.scala
@@ -2,8 +2,8 @@ package munit.internal
 
 import munit.Clue
 import munit.Location
+
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox.Context
 
 object MacroCompat {
 
@@ -11,25 +11,14 @@ object MacroCompat {
     implicit def generate: Location = macro MacroCompatScala2.locationImpl
   }
 
-  @deprecated("Use MacroCompatScala2.locationImpl instead", "2020-01-06")
-  def locationImpl(c: Context): c.Tree = MacroCompatScala2.locationImpl(c)
-
   trait ClueMacro {
     implicit def generate[T](value: T): Clue[T] =
       macro MacroCompatScala2.clueImpl
   }
 
-  @deprecated("Use MacroCompatScala2.clueImpl instead", "2020-01-06")
-  def clueImpl(c: Context)(value: c.Tree): c.Tree =
-    MacroCompatScala2.clueImpl(c)(value)
-
   trait CompileErrorMacro {
     def compileErrors(code: String): String =
       macro MacroCompatScala2.compileErrorsImpl
   }
-
-  @deprecated("Use MacroCompatScala2.compileErrorsImpl instead", "2020-01-06")
-  def compileErrorsImpl(c: Context)(value: c.Tree): c.Tree =
-    MacroCompatScala2.compileErrorsImpl(c)(value)
 
 }

--- a/munit/shared/src/main/scala/munit/Clue.scala
+++ b/munit/shared/src/main/scala/munit/Clue.scala
@@ -10,8 +10,6 @@ class Clue[+T](
   override def toString(): String = s"Clue($source, $value)"
 }
 object Clue extends MacroCompat.ClueMacro {
-  @deprecated("use fromValue instead", "1.0.0")
-  def empty[T](value: T): Clue[T] = fromValue(value)
   def fromValue[T](value: T): Clue[T] =
     new Clue("", value, "")
 }

--- a/munit/shared/src/main/scala/munit/FunFixtures.scala
+++ b/munit/shared/src/main/scala/munit/FunFixtures.scala
@@ -12,12 +12,6 @@ trait FunFixtures { self: BaseFunSuite =>
       val setup: TestOptions => Future[T],
       val teardown: T => Future[Unit]
   )(implicit dummy: DummyImplicit) { fixture =>
-    @deprecated("Use `FunFixture(...)` without `new` instead", "0.7.2")
-    def this(setup: TestOptions => T, teardown: T => Unit) =
-      this(
-        (options: TestOptions) => Future(setup(options))(munitExecutionContext),
-        (argument: T) => Future(teardown(argument))(munitExecutionContext)
-      )
 
     def test(name: String)(
         body: T => Any

--- a/munit/shared/src/main/scala/munit/package.scala
+++ b/munit/shared/src/main/scala/munit/package.scala
@@ -4,13 +4,4 @@ package object munit {
   val Flaky = new Tag("Flaky")
   val Fail = new Tag("Fail")
   val Slow = new Tag("Slow")
-
-  @deprecated("use BeforeEach instead", "1.0.0")
-  type GenericBeforeEach[T] = BeforeEach
-
-  @deprecated("use AfterEach instead", "1.0.0")
-  type GenericAfterEach[T] = AfterEach
-
-  @deprecated("use Test instead", "1.0.0")
-  type GenericTest[T] = Test
 }

--- a/project/MimaExclusions.scala
+++ b/project/MimaExclusions.scala
@@ -3,6 +3,35 @@ import com.typesafe.tools.mima.core._
 object MimaExclusions {
 
   val list = List(
+    ProblemFilters.exclude[DirectMissingMethodProblem]("munit.Clue.empty"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("munit.Clue.empty"),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "munit.FunFixtures#FunFixture.this"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "munit.internal.MacroCompat.compileErrorsImpl"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "munit.internal.MacroCompat.clueImpl"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "munit.internal.MacroCompat.locationImpl"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "munit.internal.MacroCompat.locationImpl"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "munit.internal.MacroCompat.clueImpl"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "munit.internal.MacroCompat.compileErrorsImpl"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "munit.internal.PlatformCompat.waitAtMost"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "munit.internal.PlatformCompat.waitAtMost"
+    ),
     ProblemFilters.exclude[MissingClassProblem]("munit.EmptyPrinter"),
     ProblemFilters.exclude[MissingClassProblem]("munit.EmptyPrinter$"),
     ProblemFilters.exclude[MissingClassProblem]("munit.Printer"),


### PR DESCRIPTION
I think it's high time to do it since the next option will be at 2.0.0.

After that I will do RC1, bump mima to use it and wait ~2 weeks before releasing 1.0.0?

What do people think?