### PR TITLE
Verify that the Scala 3 LTS bugfix backport doesn't break anything

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ def scala213 = "2.13.13"
 
 def scala212 = "2.12.19"
 
-def scala3 = "3.3.3"
+def scala3 = "3.4.2-RC1"
 def junitVersion = "4.13.2"
 def gcp = "com.google.cloud" % "google-cloud-storage" % "2.36.1"
 inThisBuild(

--- a/tests/shared/src/test/scala/munit/AssertionsSuite.scala
+++ b/tests/shared/src/test/scala/munit/AssertionsSuite.scala
@@ -69,17 +69,11 @@ class AssertionsSuite extends BaseSuite {
            |I found:
            |
            |    munit.Compare.compareSubtypeWithSupertype[List[Int], Vector[Int]](
-           |      /* missing */summon[List[Int] <:< Vector[Int]]
-           |    )
+           |      /* missing */summon[List[Int] <:< Vector[Int]])
            |
            |But no implicit values were found that match type List[Int] <:< Vector[Int].
-           |
-           |The following import might make progress towards fixing the problem:
-           |
-           |  import munit.CustomCompare.fromCustomEquality
-           |
            |assertEquals(List(1), Vector(1))
-           |                               ^
+           |           ^
            |""".stripMargin
       else
         """|error:
@@ -120,13 +114,8 @@ assertEquals(new A, new B)
            |    munit.Compare.compareSubtypeWithSupertype[A, B](/* missing */summon[A <:< B])
            |
            |But no implicit values were found that match type A <:< B.
-           |
-           |The following import might make progress towards fixing the problem:
-           |
-           |  import munit.CustomCompare.fromCustomEquality
-           |
            |assertEquals(new A, new B)
-           |                         ^
+           |           ^
            |""".stripMargin
       else
         """|error:
@@ -157,17 +146,11 @@ assertEquals(new A, new B)
            |I found:
            |
            |    munit.Compare.compareSubtypeWithSupertype[Char, Int](
-           |      /* missing */summon[Char <:< Int]
-           |    )
+           |      /* missing */summon[Char <:< Int])
            |
            |But no implicit values were found that match type Char <:< Int.
-           |
-           |The following import might make progress towards fixing the problem:
-           |
-           |  import munit.CustomCompare.fromCustomEquality
-           |
            |assertEquals('a', 'a'.toInt)
-           |                           ^
+           |           ^
            |""".stripMargin
       else
         """|error:
@@ -209,17 +192,11 @@ assertEquals(new A, new B)
            |I found:
            |
            |    munit.Compare.compareSubtypeWithSupertype[None.type, Some[Int]](
-           |      /* missing */summon[None.type <:< Some[Int]]
-           |    )
+           |      /* missing */summon[None.type <:< Some[Int]])
            |
            |But no implicit values were found that match type None.type <:< Some[Int].
-           |
-           |The following import might make progress towards fixing the problem:
-           |
-           |  import munit.CustomCompare.fromCustomEquality
-           |
            |assertEquals(None, Some(1))
-           |                          ^
+           |           ^
            |""".stripMargin
       else
         """|error:


### PR DESCRIPTION
As there isn't an artifact for Scala 3 LTS that includes https://github.com/scala/scala3/pull/20171 I gave it a try with 3.4.2-RC1 that already contains https://github.com/scala/scala3/pull/19737

This PR shows that the only thing that changes is the message returned form the compiler and not changes to munit are needed once Scala 3 LTS with the fix gets released.