### PR TITLE
Don't print test suite name if no test is being run

### DIFF
--- a/tests/shared/src/main/scala/munit/Issue497FrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/Issue497FrameworkSuite.scala
@@ -34,8 +34,7 @@ class Issue497FrameworkSuite extends FunSuite {
 object Issue497FrameworkSuite
     extends FrameworkTest(
       classOf[Issue497FrameworkSuite],
-      """|munit.Issue497FrameworkSuite:
-         |""".stripMargin,
+      "",
       arguments = Array("--exclude-categories=munit.Slow"),
       tags = Set(
         OnlyJVM


### PR DESCRIPTION
These changes make munit print only the test suite names of suites for which it actually ran tests, rather than printing all suite names (even those for which all tests are being filtered out), as it's been doing up to now.

For example, instead of printing things like
```text
$ ./mill -i -w scala.integration.test "almond.integration.KernelTestsSimple3.completion"
…
almond.integration.KernelTestsSimple3:
  + completion 17.073s
almond.integration.KernelTestsTwoStepStartup3:
almond.integration.KernelTestsSimple213:
almond.integration.KernelTestsTwoStepStartup212:
almond.integration.KernelTestsTwoStepStartup213:
almond.integration.KernelTestsSimple212:
```

it now prints
```text
$ ./mill -i -w scala.integration.test "almond.integration.KernelTestsSimple3.completion"
…
almond.integration.KernelTestsSimple3:
  + completion 15.468s
```

I find the latter to be more readable.