### PR TITLE
Remove Stability section because v1.x was released

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,12 +151,6 @@ The default JUnit testing syntax is based on annotations and does not feel
 idiomatic when used from Scala. MUnit tries to fill in the gap by providing a
 small Scala API on top of JUnit.
 
-## Stability
-
-MUnit is a new library with no stability guarantees. While this project is
-versioned at v0.x, it's expected that new releases, including patch releases,
-will have binary and source breaking changes.
-
 ## Inspirations
 
 MUnit is inspired by several existing testing libraries:


### PR DESCRIPTION
It is a simple change that remove Stability section of the documentation because project is now published with v1.x tags.