### PR TITLE
bugfix: Print stack trace for assertEquals

### DIFF
--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -275,7 +275,7 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
       obtained,
       expected,
       loc,
-      isStackTracesEnabled = false
+      isStackTracesEnabled = true
     )
   }
 

--- a/tests/shared/src/main/scala/munit/StackTraceFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/StackTraceFrameworkSuite.scala
@@ -28,6 +28,9 @@ object FullStackTraceFrameworkSuite
     extends BaseStackTraceFrameworkSuite(
       Array("-F"),
       """|at munit.Assertions:failComparison
+         |  at munit.Assertions:failComparison$
+         |  at munit.FunSuite:failComparison
+         |  at munit.Assertions$$anon$1:handle
          |==> failure munit.StackTraceFrameworkSuite.fail - tests/shared/src/main/scala/munit/StackTraceFrameworkSuite.scala:5
          |4:  test("fail") {
          |5:    assertNoDiff("a", "b")
@@ -44,7 +47,9 @@ object FullStackTraceFrameworkSuite
 object SmallStackTraceFrameworkSuite
     extends BaseStackTraceFrameworkSuite(
       Array(),
-      """|at munit.Assertions:failComparison
+      """|at munit.FunSuite:assertNoDiff
+         |  at munit.StackTraceFrameworkSuite:$anonfun$new$1
+         |  at scala.runtime.java8.JFunction0$mcV$sp:apply
          |==> failure munit.StackTraceFrameworkSuite.fail - tests/shared/src/main/scala/munit/StackTraceFrameworkSuite.scala:5
          |4:  test("fail") {
          |5:    assertNoDiff("a", "b")


### PR DESCRIPTION
Not sure why not show the stack trace and it's rather unexpected

Fixes https://github.com/scalameta/munit/issues/782

Opinions @valencik @mzuehlke ?