### PR TITLE
Consider a -source and -target version for javac

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,7 @@ val sharedNativeConfigure: Project => Project =
   _.disablePlugins(ScalafixPlugin, MimaPlugin)
 
 val sharedSettings = List(
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 11)) =>


### PR DESCRIPTION
This avoids building e.g. IgnoreSuite targeting the latest class file version supported by the JDK used at build time.

https://github.com/scalameta/munit/issues/868