### PR TITLE
Diff: swap the order of expected-vs-obtained

### DIFF
--- a/munit-diff/shared/src/main/scala/munit/diff/Diff.scala
+++ b/munit-diff/shared/src/main/scala/munit/diff/Diff.scala
@@ -12,7 +12,7 @@ class Diff(val obtained: String, val expected: String) extends Serializable {
   val expectedClean: String = AnsiColors.filterAnsi(expected)
   val obtainedLines: Seq[String] = splitIntoLines(obtainedClean)
   val expectedLines: Seq[String] = splitIntoLines(expectedClean)
-  val unifiedDiff: String = createUnifiedDiff(obtainedLines, expectedLines)
+  val unifiedDiff: String = createUnifiedDiff(expectedLines, obtainedLines)
   def isEmpty: Boolean = unifiedDiff.isEmpty
 
   def createReport(
@@ -42,7 +42,7 @@ class Diff(val obtained: String, val expected: String) extends Serializable {
     val red = AnsiColors.use(AnsiColors.LightRed)
     val reset = AnsiColors.use(AnsiColors.Reset)
     val green = AnsiColors.use(AnsiColors.LightGreen)
-    sb.append(s" ($red- obtained$reset, $green+ expected$reset)")
+    sb.append(s" ($red- expected$reset, $green+ obtained$reset)")
     sb.append("\n")
     sb.append(unifiedDiff)
   }
@@ -74,7 +74,7 @@ object Diff {
     val result =
       if (diff.getDeltas.isEmpty) ""
       else DiffUtils
-        .generateUnifiedDiff("obtained", "expected", original.asJava, diff, 1)
+        .generateUnifiedDiff("expected", "obtained", original.asJava, diff, 1)
         .asScala.iterator.drop(2).filterNot(_.startsWith("@@"))
         .map(line => if (line.lastOption.contains(' ')) line + "∙" else line)
         .map(line =>

--- a/tests/shared/src/main/scala/munit/AssertionsFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/AssertionsFrameworkSuite.scala
@@ -58,9 +58,9 @@ object AssertionsFrameworkSuite
          |values are not the same
          |=> Obtained
          |a.A()
-         |=> Diff (- obtained, + expected)
-         |-a.A()
-         |+b.B()
+         |=> Diff (- expected, + obtained)
+         |-b.B()
+         |+a.A()
          |==> failure munit.AssertionsFrameworkSuite.toString-has-different-whitespace - tests/shared/src/main/scala/munit/AssertionsFrameworkSuite.scala:39 values are not equal, even if their text representation only differs in leading/trailing whitespace and ANSI escape characters: foo
          |38:  test("toString-has-different-whitespace")(
          |39:    assertEquals[Any, Any]("foo", "foo  ")

--- a/tests/shared/src/main/scala/munit/DiffProductFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/DiffProductFrameworkSuite.scala
@@ -27,12 +27,12 @@ object DiffProductFrameworkSuite
          |    2
          |  )
          |)
-         |=> Diff (- obtained, + expected)
+         |=> Diff (- expected, + obtained)
          |   name = "John",
-         |-  age = 43,
-         |+  age = 42,
+         |-  age = 42,
+         |+  age = 43,
          |   friends = List(
-         |+    1,
+         |-    1,
          |     2
          |""".stripMargin,
     )

--- a/tests/shared/src/main/scala/munit/Issue179FrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/Issue179FrameworkSuite.scala
@@ -15,8 +15,8 @@ object Issue179FrameworkSuite
          |=> Obtained
          |    '''|
          |       |'''.stripMargin
-         |=> Diff (- obtained, + expected)
-         |-
-         |+A
+         |=> Diff (- expected, + obtained)
+         |-A
+         |+
          |""".stripMargin,
     )

--- a/tests/shared/src/main/scala/munit/StackTraceFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/StackTraceFrameworkSuite.scala
@@ -33,9 +33,9 @@ object FullStackTraceFrameworkSuite
          |diff assertion failed
          |=> Obtained
          |"a"
-         |=> Diff (- obtained, + expected)
-         |-a
-         |+b
+         |=> Diff (- expected, + obtained)
+         |-b
+         |+a
          |""".stripMargin,
     )
 
@@ -52,8 +52,8 @@ object SmallStackTraceFrameworkSuite
          |diff assertion failed
          |=> Obtained
          |"a"
-         |=> Diff (- obtained, + expected)
-         |-a
-         |+b
+         |=> Diff (- expected, + obtained)
+         |-b
+         |+a
          |""".stripMargin,
     )

--- a/tests/shared/src/main/scala/munit/TestTransformFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/TestTransformFrameworkSuite.scala
@@ -35,9 +35,9 @@ object TestTransformFrameworkSuite
          |values are not the same
          |=> Obtained
          |0
-         |=> Diff (- obtained, + expected)
-         |-0
-         |+1
+         |=> Diff (- expected, + obtained)
+         |-1
+         |+0
          |==> extra info
          |""".stripMargin,
     )

--- a/tests/shared/src/test/scala/munit/ComparisonFailExceptionSuite.scala
+++ b/tests/shared/src/test/scala/munit/ComparisonFailExceptionSuite.scala
@@ -37,13 +37,13 @@ class ComparisonFailExceptionSuite extends BaseSuite {
          |  "2",
          |  "3"
          |)
-         |=> Diff (- obtained, + expected)
+         |=> Diff (- expected, + obtained)
          | List(
-         |-  "1",
-         |-  "2",
-         |-  "3"
-         |+  1,
-         |+  2
+         |-  1,
+         |-  2
+         |+  "1",
+         |+  "2",
+         |+  "3"
          | )
          |""".stripMargin,
     )

--- a/tests/shared/src/test/scala/munit/DiffsSuite.scala
+++ b/tests/shared/src/test/scala/munit/DiffsSuite.scala
@@ -10,9 +10,9 @@ class DiffsSuite extends FunSuite {
     // intuitive results.
     assertNoDiff(
       obtained,
-      """|-a
-         |-+b
-         |++c
+      """|--c
+         |+-b
+         | +a
          |""".stripMargin,
     )
   }
@@ -28,8 +28,8 @@ class DiffsSuite extends FunSuite {
     "trailing-whitespace",
     "a\nb",
     "a \nb",
-    """|-a
-       |+a ∙
+    """|-a ∙
+       |+a
        | b
        |""".stripMargin,
   )


### PR DESCRIPTION
It was mapping obtained to original, and expected to revised.