### PR TITLE
Compare: use implicit Location

### DIFF
--- a/munit/shared/src/main/scala/munit/Assertions.scala
+++ b/munit/shared/src/main/scala/munit/Assertions.scala
@@ -97,7 +97,7 @@ trait Assertions extends MacroCompat.CompileErrorMacro {
             )
           case _ =>
         }
-        compare.failEqualsComparison(obtained, expected, clue, loc, this)
+        compare.failEqualsComparison(obtained, expected, clue, this)
       }
     }
 


### PR DESCRIPTION
Part 1 of 2 in modifying assert failure output.