### PR TITLE
Diff: add new DiffOptions parameter

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -196,6 +196,67 @@ List(
 ...
 ```
 
+## Customizing the diff output
+
+When a test fails, Munit shows a rich unified diff, to easily spot the difference
+between the test result and the expected value.
+
+However, identifying where the reported discrepancy actually is can sometimes be
+difficult, especially with values found in multiple locations.
+
+To customize what's being displayed, one can define an `implicit` instance of the
+`munit.diff.DiffOptions` class which contains the following methods:
+- `withContextSize(Int)`: number of lines of context to show around the
+  modified lines (default: 1)
+- `withShowLines(Boolean)`: shows the usual unified diff patch preamble
+  `@@ -aa,bb +cc,dd @@` (default: false)
+- `withObtainedAsStripMargin(Boolean)`: displays the value obtained as
+  triple-quoted string with margins (default: false)
+
+```scala mdoc
+import munit.FunSuite
+
+class CustomContextSizeTest extends FunSuite {
+  private implicit val diffOptions = munit.diff.DiffOptions.withContextSize(10)
+
+  test("contextSize") {
+    val a = List("a", "a", "a", "a", "a", "a", "a", "a", "a")
+    val b = List("a", "a", "a", "a", "b", "a", "a", "a", "a")
+    assertEquals(a,b)
+  }
+}
+```
+
+will include
+
+```
+=> Diff (- expected, + obtained)
+ List(
+   "a",
+   "a",
+   "a",
+   "a",
+-  "b",
+   "a",
+   "a",
+   "a",
++  "a",
+   "a"
+ )
+```
+
+while the default output is more compact:
+
+```
+=> Diff (- expected, + obtained)
+   "a",
+-  "b",
+   "a",
+   "a",
++  "a",
+   "a"
+```
+
 ## Run tests in parallel
 
 MUnit does not support running individual test cases in parallel. However, sbt

--- a/munit-diff/shared/src/main/scala/munit/diff/DiffOptions.scala
+++ b/munit-diff/shared/src/main/scala/munit/diff/DiffOptions.scala
@@ -1,0 +1,31 @@
+package munit.diff
+
+class DiffOptions private (
+    val contextSize: Int,
+    val showLines: Boolean,
+    val obtainedAsStripMargin: Boolean,
+) {
+  private def privateCopy(
+      contextSize: Int = this.contextSize,
+      showLines: Boolean = this.showLines,
+      obtainedAsStripMargin: Boolean = this.obtainedAsStripMargin,
+  ): DiffOptions = new DiffOptions(
+    contextSize = contextSize,
+    showLines = showLines,
+    obtainedAsStripMargin = obtainedAsStripMargin,
+  )
+
+  def withContextSize(value: Int): DiffOptions = privateCopy(contextSize = value)
+  def withShowLines(value: Boolean): DiffOptions = privateCopy(showLines = value)
+  def withObtainedAsStripMargin(value: Boolean): DiffOptions =
+    privateCopy(obtainedAsStripMargin = value)
+}
+
+object DiffOptions
+    extends DiffOptions(
+      contextSize = 1,
+      showLines = false,
+      obtainedAsStripMargin = false,
+    ) {
+  implicit val default: DiffOptions = this
+}

--- a/munit-diff/shared/src/main/scala/munit/diff/Diffs.scala
+++ b/munit-diff/shared/src/main/scala/munit/diff/Diffs.scala
@@ -1,5 +1,6 @@
 package munit.diff
 
+@deprecated("Please use Diff instead", "1.0.4")
 object Diffs {
 
   def create(obtained: String, expected: String): Diff =

--- a/munit/shared/src/main/scala/munit/Compare.scala
+++ b/munit/shared/src/main/scala/munit/Compare.scala
@@ -1,5 +1,7 @@
 package munit
 
+import munit.diff.DiffOptions
+
 import scala.annotation.implicitNotFound
 
 /**
@@ -55,7 +57,7 @@ trait Compare[A, B] {
       expected: B,
       title: Any,
       assertions: Assertions,
-  )(implicit loc: Location): Nothing = {
+  )(implicit loc: Location, options: DiffOptions): Nothing = {
     val diffHandler: ComparisonFailExceptionHandler = {
       (message: String, _obtained: String, _expected: String, _loc: Location) =>
         implicit val loc: Location = _loc
@@ -68,7 +70,6 @@ trait Compare[A, B] {
       assertions.munitPrint(expected),
       diffHandler,
       title = assertions.munitPrint(title),
-      printObtainedAsStripMargin = false,
     )
 
     // Attempt 2: try with `.toString` in case `munitPrint()` produces identical
@@ -80,7 +81,6 @@ trait Compare[A, B] {
       expectedStr,
       diffHandler,
       title = assertions.munitPrint(title),
-      printObtainedAsStripMargin = false,
     )
 
     // Attempt 3: string comparison is not working, unconditionally fail the test.

--- a/munit/shared/src/main/scala/munit/Diffs.scala
+++ b/munit/shared/src/main/scala/munit/Diffs.scala
@@ -1,9 +1,12 @@
 package munit
 
 import munit.diff.Diff
+import munit.diff.DiffOptions
 
 object Diffs {
 
+  // for MIMA compatibility
+  @deprecated("Use version with implicit DiffOptions", "1.0.4")
   def assertNoDiff(
       obtained: String,
       expected: String,
@@ -11,20 +14,26 @@ object Diffs {
       title: String,
       printObtainedAsStripMargin: Boolean,
   )(implicit loc: Location): Boolean = {
-    if (obtained.isEmpty && !expected.isEmpty) {
+    implicit val diffOptions: DiffOptions = DiffOptions
+      .withObtainedAsStripMargin(printObtainedAsStripMargin)
+    assertNoDiff(obtained, expected, handler, title)
+  }
+
+  def assertNoDiff(
+      obtained: String,
+      expected: String,
+      handler: ComparisonFailExceptionHandler,
+      title: String,
+  )(implicit loc: Location, options: DiffOptions): Boolean = {
+    if (obtained.isEmpty && expected.nonEmpty) {
       val msg = s"""|Obtained empty output!
                     |=> Expected:
                     |$expected""".stripMargin
       handler.handle(msg, obtained, expected, loc)
     }
-    val diff = new Diff(obtained, expected)
+    val diff = Diff(obtained, expected)
     if (diff.isEmpty) true
-    else handler.handle(
-      diff.createReport(title, printObtainedAsStripMargin),
-      obtained,
-      expected,
-      loc,
-    )
+    else handler.handle(diff.createReport(title), obtained, expected, loc)
   }
 
 }

--- a/tests/shared/src/main/scala/munit/Issue179FrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/Issue179FrameworkSuite.scala
@@ -13,8 +13,8 @@ object Issue179FrameworkSuite
          |5:}
          |diff assertion failed
          |=> Obtained
-         |    '''|
-         |       |'''.stripMargin
+         |
+         |
          |=> Diff (- expected, + obtained)
          |-A
          |+

--- a/tests/shared/src/main/scala/munit/StackTraceFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/StackTraceFrameworkSuite.scala
@@ -32,7 +32,7 @@ object FullStackTraceFrameworkSuite
          |5:}
          |diff assertion failed
          |=> Obtained
-         |"a"
+         |a
          |=> Diff (- expected, + obtained)
          |-b
          |+a
@@ -51,7 +51,7 @@ object SmallStackTraceFrameworkSuite
          |5:}
          |diff assertion failed
          |=> Obtained
-         |"a"
+         |a
          |=> Diff (- expected, + obtained)
          |-b
          |+a


### PR DESCRIPTION
Sets diff context size and optionally outputs line offsets. This is part 2, following #881. Builds upon #788.