### PR TITLE
DiffOptions: allow controlling use of ANSI markers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import scala.collection.mutable
 
-import sbtcrossproject.CrossPlugin.autoImport.CrossType
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 def previousVersion = "1.0.0-RC1"
 
@@ -59,7 +58,8 @@ def isScala3(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 3)
 lazy val skipIdeaSettings = SettingKey[Boolean]("ide-skip-project")
   .withRank(KeyRanks.Invisible) := true
 lazy val mimaEnable: List[Def.Setting[_]] = List(
-  mimaBinaryIssueFilters ++= List.empty,
+  mimaBinaryIssueFilters +=
+    _root_.munit.build.Mima.languageAgnosticCompatibilityPolicy,
   mimaPreviousArtifacts := {
     if (crossPaths.value)
       Set("org.scalameta" %% moduleName.value % previousVersion)

--- a/munit-diff/shared/src/main/scala/munit/diff/DiffOptions.scala
+++ b/munit-diff/shared/src/main/scala/munit/diff/DiffOptions.scala
@@ -1,22 +1,30 @@
 package munit.diff
 
 class DiffOptions private (
+    val forceAnsi: Option[Boolean],
     val contextSize: Int,
     val showLines: Boolean,
     val obtainedAsStripMargin: Boolean,
     val printer: Option[Printer],
 ) {
   private def privateCopy(
+      forceAnsi: Option[Boolean] = this.forceAnsi,
       contextSize: Int = this.contextSize,
       showLines: Boolean = this.showLines,
       obtainedAsStripMargin: Boolean = this.obtainedAsStripMargin,
       printer: Option[Printer] = this.printer,
   ): DiffOptions = new DiffOptions(
+    forceAnsi = forceAnsi,
     contextSize = contextSize,
     showLines = showLines,
     obtainedAsStripMargin = obtainedAsStripMargin,
     printer = printer,
   )
+
+  def withForceAnsi(value: Option[Boolean]): DiffOptions =
+    privateCopy(forceAnsi = value)
+  def ansi(orElse: => Boolean): Boolean = forceAnsi.getOrElse(orElse)
+  def ansi: Boolean = ansi(true)
 
   def withContextSize(value: Int): DiffOptions = privateCopy(contextSize = value)
   def withShowLines(value: Boolean): DiffOptions = privateCopy(showLines = value)
@@ -28,6 +36,7 @@ class DiffOptions private (
 
 object DiffOptions
     extends DiffOptions(
+      forceAnsi = None,
       contextSize = 1,
       showLines = false,
       obtainedAsStripMargin = false,

--- a/munit-diff/shared/src/main/scala/munit/diff/console/AnsiColors.scala
+++ b/munit-diff/shared/src/main/scala/munit/diff/console/AnsiColors.scala
@@ -21,6 +21,11 @@ object AnsiColors {
 
   def c(s: String, colorSequence: String): String =
     if (colorSequence == null || noColor) s else colorSequence + s + Reset
+  def c(colorSequence: String, flag: Boolean = false)(
+      f: StringBuilder => Unit
+  )(implicit sb: StringBuilder): Unit =
+    if (!flag || colorSequence == null || noColor) f(sb)
+    else { sb.append(colorSequence); f(sb); sb.append(Reset) }
 
   def filterAnsi(s: String): String =
     if (s == null) null

--- a/munit/shared/src/main/scala/munit/SuiteTransforms.scala
+++ b/munit/shared/src/main/scala/munit/SuiteTransforms.scala
@@ -34,9 +34,10 @@ trait SuiteTransforms {
       if (onlySuite.nonEmpty)
         if (!isCI) onlySuite
         else onlySuite.map(t =>
-          if (t.tags(Only)) t.withBody(() =>
-            fail("'Only' tag is not allowed when `isCI=true`")(t.location)
-          )
+          if (t.tags(Only)) t.withBody { () =>
+            implicit val loc = t.location
+            fail("'Only' tag is not allowed when `isCI=true`")
+          }
           else t
         )
       else tests

--- a/munit/shared/src/main/scala/munit/internal/console/Lines.scala
+++ b/munit/shared/src/main/scala/munit/internal/console/Lines.scala
@@ -2,6 +2,7 @@ package munit.internal.console
 
 import munit.Clues
 import munit.Location
+import munit.diff.console.AnsiColors
 import munit.internal.io.PlatformIO.Files
 import munit.internal.io.PlatformIO.Path
 import munit.internal.io.PlatformIO.Paths
@@ -13,8 +14,6 @@ import scala.util.control.NonFatal
 class Lines extends Serializable {
   private val filecache = mutable.Map.empty[Path, Array[String]]
 
-  def formatLine(location: Location, message: String): String =
-    formatLine(location, message, new Clues(Nil))
   def formatPath(location: Location): String = location.path
 
   def findPath(cwd: String, path: String, max: Int): Path = {
@@ -32,28 +31,30 @@ class Lines extends Serializable {
     else findPath(getParentPath(cwd, "/"), path, max - 1)
   }
 
-  def formatLine(location: Location, message: String, clues: Clues): String =
+  def formatLine(
+      location: Location,
+      message: String,
+      clues: Clues = Clues.empty,
+      ansi: Boolean = true,
+  ): String =
     try {
       val path = findPath(Path.workingDirectory.toString, location.path, 3)
       val lines = filecache
         .getOrElseUpdate(path, Files.readAllLines(path).asScala.toArray)
       val slice = lines.slice(location.line - 2, location.line + 1)
-      val out = new StringBuilder()
+      implicit val out: StringBuilder = new StringBuilder()
       if (slice.length >= 2) {
-        val width = (location.line + 1).toString().length() + 1
+        val width = (location.line + 1).toString.length() + 1
         def format(n: Int): String = s"$n:".padTo(width, ' ')
         val isMultilineMessage = message.contains('\n')
-        out.append(formatPath(location)).append(':')
-          .append(location.line.toString())
-        if (message.length() > 0 && !isMultilineMessage) out.append(" ")
+        out.append(formatPath(location)).append(':').append(location.line)
+        if (message.nonEmpty && !isMultilineMessage) out.append(" ")
           .append(message)
         out.append('\n').append(format(location.line - 1)).append(slice(0))
-          .append('\n').append(munit.diff.console.AnsiColors.use(
-            munit.diff.console.AnsiColors.Reversed
-          )).append(format(location.line)).append(slice(1))
-          .append(munit.diff.console.AnsiColors.use(
-            munit.diff.console.AnsiColors.Reset
-          ))
+          .append('\n')
+        AnsiColors.c(AnsiColors.Reversed, ansi)(
+          _.append(format(location.line)).append(slice(1))
+        )
         if (slice.length >= 3) out.append('\n').append(format(location.line + 1))
           .append(slice(2))
         if (isMultilineMessage) out.append('\n').append(message)

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -1,0 +1,20 @@
+package munit.build
+
+import com.typesafe.tools.mima.core.*
+
+// More details about Mima:
+// https://github.com/typesafehub/migration-manager/wiki/sbt-plugin#basic-usage
+object Mima {
+  val languageAgnosticCompatibilityPolicy: ProblemFilter = (problem: Problem) => {
+    val fullName = problem match {
+      case problem: TemplateProblem =>
+        val ref = problem.ref
+        ref.fullName
+      case problem: MemberProblem =>
+        val ref = problem.ref
+        ref.fullName
+    }
+
+    !fullName.startsWith("munit.internal.")
+  }
+}


### PR DESCRIPTION
Also, exclude `munit.internal.` from MIMA.