### PR TITLE
Fix munit-scalacheck version

### DIFF
--- a/docs/integrations/scalacheck.md
+++ b/docs/integrations/scalacheck.md
@@ -12,7 +12,7 @@ ScalaCheck support is provided as a separate module. You can add it to your
 build via:
 
 ```scala
-libraryDependencies += "org.scalameta" %% "munit-scalacheck" % "@STABLE_VERSION@" % Test
+libraryDependencies += "org.scalameta" %% "munit-scalacheck" % "1.1.0" % Test
 ```
 
 You can then extend `ScalaCheckSuite` and write ScalaCheck property tests:


### PR DESCRIPTION
The displayed version in the website is `1.0.4` (a.k.a `STABLE_VERSION`) which doesn't even exist