### PR TITLE
MunitRunner: make sure to call fireTestFinished

### DIFF
--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -243,7 +243,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
     }
 
     notifier.fireTestStarted(description)
-    def handleNonFatalOrStackOverflow(ex: Throwable): Future[Unit] = {
+    def handleNonFatalOrStackOverflow(ex: Throwable): Unit = {
       trimStackTrace(ex)
       val cause = Exceptions.rootCause(ex)
       val failure = new Failure(description, cause)
@@ -255,28 +255,27 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
           notifier.fireTestFailure(failure)
         case _ => notifier.fireTestFailure(failure)
       }
-      Future.successful(())
     }
 
-    val onError: PartialFunction[Throwable, Future[Unit]] = {
+    def onError(ex: Throwable): Unit = ex match {
       case ex: AssumptionViolatedException =>
         trimStackTrace(ex)
         notifier.fireTestAssumptionFailed(new Failure(description, ex))
-        Future.successful(())
       case NonFatal(ex) => handleNonFatalOrStackOverflow(ex)
       case ex: StackOverflowError => handleNonFatalOrStackOverflow(ex)
       case ex =>
         suiteAborted = true
         notifier.fireTestFailure(new Failure(description, ex))
-        Future.successful(())
     }
-    val result: Future[Unit] =
-      try runTestBody(notifier, description, test).recoverWith(onError)
-      catch onError
-    result.map { _ =>
+
+    def onResult(res: Try[Unit]): Future[Boolean] = {
+      res.failed.foreach(onError)
       notifier.fireTestFinished(description)
-      !test.tags(Pending)
+      Future.successful(!test.tags(Pending))
     }
+
+    try runTestBody(notifier, description, test).transformWith(onResult)
+    catch { case ex: Throwable => onResult(util.Failure(ex)) }
   }
 
   private def futureFromAny(any: Any): Future[Any] = any match {


### PR DESCRIPTION
Previously, since `.map` was used on the resulting future, this step may have been skipped.

Instead, refactor `runTest` a little to handle errors and Finished flag correctly.