### PR TITLE
MunitRunner: use simple Iterator, not LazyList

### DIFF
--- a/munit/shared/src/main/scala-2.13/munit/internal/Compat.scala
+++ b/munit/shared/src/main/scala-2.13/munit/internal/Compat.scala
@@ -1,8 +1,6 @@
 package munit.internal
 
 object Compat {
-  type LazyList[+T] = scala.LazyList[T]
-  val LazyList = scala.LazyList
   def productElementNames(p: Product): Iterator[String] = p.productElementNames
   def collectionClassName(i: Iterable[_]): String = i
     .asInstanceOf[{ def collectionClassName: String }].collectionClassName

--- a/munit/shared/src/main/scala-3/munit/internal/Compat.scala
+++ b/munit/shared/src/main/scala-3/munit/internal/Compat.scala
@@ -3,8 +3,6 @@ package munit.internal
 import scala.reflect.Selectable.reflectiveSelectable
 
 object Compat {
-  type LazyList[+T] = scala.LazyList[T]
-  val LazyList = scala.LazyList
   def productElementNames(p: Product): Iterator[String] = p.productElementNames
   def collectionClassName(i: Iterable[_]): String = i
     .asInstanceOf[{ def collectionClassName: String }].collectionClassName

--- a/munit/shared/src/main/scala-pre-2.13/munit/internal/Compat.scala
+++ b/munit/shared/src/main/scala-pre-2.13/munit/internal/Compat.scala
@@ -1,8 +1,6 @@
 package munit.internal
 
 object Compat {
-  type LazyList[+T] = Stream[T]
-  val LazyList = scala.Stream
   def productElementNames(p: Product): Iterator[String] = Iterator
     .continually("")
   def collectionClassName(i: Iterable[_]): String = i.stringPrefix

--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -74,7 +74,7 @@ class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
     .getOrElseUpdate(
       test, {
         val escapedName = Printers.escapeNonVisible(test.name)
-        val testName = munit.internal.Compat.LazyList.from(0).map {
+        val testName = Iterator.from(0).map {
           case 0 => escapedName
           case n => s"$escapedName-$n"
         }.find(candidate => !testNames.contains(candidate)).head


### PR DESCRIPTION
There's no need to persist the values in the LazyList when they are not going to be reused.