### PR TITLE
bugfix: Fix releasing process

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.7.1")


### PR DESCRIPTION
We can't migrate to 1.11.0 until the namespace gets migrated by sonatype