### PR TITLE
MUnitRunner: take a suite in the constructor

### DIFF
--- a/munit/js/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/js/src/main/scala/munit/internal/PlatformCompat.scala
@@ -80,7 +80,7 @@ object PlatformCompat {
     .lookupInstantiatableClass(taskDef.fullyQualifiedName()).map(cls =>
       new MUnitRunner(
         cls.runtimeClass.asInstanceOf[Class[_ <: munit.Suite]],
-        () => cls.newInstance().asInstanceOf[munit.Suite],
+        cls.newInstance().asInstanceOf[munit.Suite],
       )
     )
   private var myClassLoader: ClassLoader = _

--- a/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
@@ -108,7 +108,7 @@ object PlatformCompat {
     .lookupInstantiatableClass(taskDef.fullyQualifiedName()).map(cls =>
       new MUnitRunner(
         cls.runtimeClass.asInstanceOf[Class[_ <: munit.Suite]],
-        () => cls.newInstance().asInstanceOf[munit.Suite],
+        cls.newInstance().asInstanceOf[munit.Suite],
       )
     )
   private var myClassLoader: ClassLoader = _

--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -22,13 +22,14 @@ import org.junit.runner.manipulation.Filterable
 import org.junit.runner.notification.Failure
 import org.junit.runner.notification.RunNotifier
 
-class MUnitRunner(val cls: Class[_ <: Suite], newInstance: () => Suite)
+class MUnitRunner(val cls: Class[_ <: Suite], suite: Suite)
     extends Runner with Filterable with Configurable {
 
-  def this(cls: Class[_ <: Suite]) =
-    this(MUnitRunner.ensureEligibleConstructor(cls), () => cls.newInstance())
+  def this(cls: Class[_ <: Suite], newInstance: () => Suite) =
+    this(cls, newInstance())
 
-  val suite: Suite = newInstance()
+  def this(cls: Class[_ <: Suite]) =
+    this(MUnitRunner.ensureEligibleConstructor(cls), cls.newInstance())
 
   private implicit val ec: ExecutionContext = suite.munitExecutionContext
 


### PR DESCRIPTION
Since the `val suite` was being initialized non-lazily, there's no real reason to pass a function.