### PR TITLE
Do not swallow exceptions in afterEach. Fixes #966

### DIFF
--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -269,23 +269,59 @@ class MUnitRunner(val cls: Class[_ <: Suite], suite: Suite)
       notifier: RunNotifier,
       description: Description,
       test: Test,
-  ): Future[Unit] = runBeforeEach(test).flatMap[Any] { beforeEach =>
-    def afterEach() = runAfterEach(test, beforeEach.loadedFixtures)
-    beforeEach.errors match {
-      case Nil => StackTraces.dropOutside(test.body())
-          .transformWith(result => afterEach().transform(_ => result))
-      case error :: errors =>
-        afterEach()
-        errors.foreach(err => error.addSuppressed(err))
-        Future.failed(error)
+  ): Future[Unit] = {
+    import scala.util.{Failure => TryFailure}
+    import scala.util.{Success => TrySuccess}
+    import org.junit.runner.notification.{Failure => JunitFailure}
+
+    def addSuppressed(firstError: Throwable, otherErrors: Seq[Throwable]) = {
+      otherErrors.foreach(err => firstError.addSuppressed(err))
+      firstError
     }
-  }.map {
-    case f: TestValues.FlakyFailure =>
-      trimStackTrace(f)
-      notifier.fireTestAssumptionFailed(new Failure(description, f))
-    case TestValues.Ignore => notifier.fireTestIgnored(description)
-    case _ if test.tags(Pending) => notifier.fireTestIgnored(description)
-    case _ => ()
+
+    runBeforeEach(test).flatMap[Any] { beforeEach =>
+      sealed trait Outcome
+      case class BeforeEachFailure(exceptions: List[Throwable]) extends Outcome
+      case class TestFailure(exception: Throwable) extends Outcome
+      case class TestSuccess(testResult: Any) extends Outcome
+
+      (beforeEach.errors match {
+        case Nil => StackTraces.dropOutside(test.body()).transform {
+            case TrySuccess(testResult) => TrySuccess(TestSuccess(testResult))
+            case TryFailure(testException) =>
+              TrySuccess(TestFailure(testException))
+          }
+        case errors => Future.successful(BeforeEachFailure(errors))
+      }).flatMap { outcome =>
+        runAfterEach(test, beforeEach.loadedFixtures).transform {
+          case TryFailure(afterEachException) =>
+            TrySuccess(List(afterEachException))
+          case TrySuccess(afterEachExceptions) =>
+            TrySuccess(afterEachExceptions.collect { case TryFailure(e) => e })
+        }.flatMap { afterEachErrors =>
+          outcome match {
+            case BeforeEachFailure(beforeEachErrors) => Future
+                .failed(addSuppressed(
+                  beforeEachErrors.head,
+                  beforeEachErrors.tail ++ afterEachErrors,
+                ))
+            case TestFailure(testException) => Future
+                .failed(addSuppressed(testException, afterEachErrors))
+            case TestSuccess(testResult) =>
+              if (afterEachErrors.isEmpty) Future.successful(testResult)
+              else Future
+                .failed(addSuppressed(afterEachErrors.head, afterEachErrors.tail))
+          }
+        }
+      }
+    }.map {
+      case f: TestValues.FlakyFailure =>
+        trimStackTrace(f)
+        notifier.fireTestAssumptionFailed(new JunitFailure(description, f))
+      case TestValues.Ignore => notifier.fireTestIgnored(description)
+      case _ if test.tags(Pending) => notifier.fireTestIgnored(description)
+      case _ => ()
+    }
   }
 
   private def runHiddenTest(

--- a/tests/shared/src/main/scala/munit/AfterEachExceptionSuite.scala
+++ b/tests/shared/src/main/scala/munit/AfterEachExceptionSuite.scala
@@ -1,0 +1,19 @@
+package munit
+
+/** Tests that an uncaught exception in afterEach is not swallowed and aborts the suite */
+class AfterEachExceptionSuite extends FunSuite {
+
+  override def afterEach(context: AfterEach): Unit =
+    throw new RuntimeException("Exception in afterEach")
+
+  test("should run")(assertEquals(1, 1))
+
+  test("should not run")(assertEquals(1, 1))
+}
+object AfterEachExceptionSuite
+    extends FrameworkTest(
+      classOf[AfterEachExceptionSuite],
+      """==> failure munit.AfterEachExceptionSuite.should run - Teardown of test failed
+        |==> skipped munit.AfterEachExceptionSuite.should not run - Suite has been aborted
+        |""".stripMargin,
+    )

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -2,6 +2,7 @@ package munit
 
 class FrameworkSuite extends BaseFrameworkSuite {
   val tests: List[FrameworkTest] = List[FrameworkTest](
+    AfterEachExceptionSuite,
     SwallowedExceptionSuite,
     InterceptFrameworkSuite,
     CiOnlyFrameworkSuite,


### PR DESCRIPTION
This should fix the issue in #966. I couldn't figure out how to write a test for it. Someone should probably do that before merging to make sure that it works as expected. 