### PR TITLE
bugfix: Add back FutureCompat to avoid binary compat issues

### DIFF
--- a/munit/shared/src/main/scala/munit/internal/FutureCompat.scala
+++ b/munit/shared/src/main/scala/munit/internal/FutureCompat.scala
@@ -1,0 +1,27 @@
+package munit.internal
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.Try
+
+/**
+ * This class is not used and should not be used, but it's kept
+ * for backward compatibility with munit-scalacheck.
+ */
+@deprecated
+private[munit] object FutureCompat {
+  implicit class ExtensionFuture[T](f: Future[T]) {
+    @deprecated
+    def flattenCompat[S](ec: ExecutionContext)(implicit
+        ev: T <:< Future[S]
+    ): Future[S] = f.flatten
+    @deprecated
+    def transformCompat[B](fn: Try[T] => Try[B])(implicit
+        ec: ExecutionContext
+    ): Future[B] = f.transform(fn)
+    @deprecated
+    def transformWithCompat[B](fn: Try[T] => Future[B])(implicit
+        ec: ExecutionContext
+    ): Future[B] = f.transformWith(fn)
+  }
+}


### PR DESCRIPTION
The issues might happen if new munit is used and older scalacheck.