### PR TITLE
PlatformCompat: define jsJVM/isJS/isNative as final val

### DIFF
--- a/munit/js/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/js/src/main/scala/munit/internal/PlatformCompat.scala
@@ -69,9 +69,9 @@ object PlatformCompat {
   // Scala.js does not support looking up annotations at runtime.
   def isIgnoreSuite(cls: Class[_]): Boolean = false
 
-  final def isJVM: Boolean = false
-  final def isJS: Boolean = true
-  final def isNative: Boolean = false
+  final val isJVM = false
+  final val isJS = true
+  final val isNative = false
 
   def newRunner(
       taskDef: TaskDef,

--- a/munit/jvm/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/jvm/src/main/scala/munit/internal/PlatformCompat.scala
@@ -79,9 +79,9 @@ object PlatformCompat {
 
   def isIgnoreSuite(cls: Class[_]): Boolean = cls
     .getAnnotationsByType(classOf[munit.IgnoreSuite]).nonEmpty
-  final def isJVM: Boolean = true
-  final def isJS: Boolean = false
-  final def isNative: Boolean = false
+  final val isJVM = true
+  final val isJS = false
+  final val isNative = false
   def getThisClassLoader: ClassLoader = this.getClass().getClassLoader()
 
   type InvocationTargetException = java.lang.reflect.InvocationTargetException

--- a/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
+++ b/munit/native/src/main/scala/munit/internal/PlatformCompat.scala
@@ -97,9 +97,9 @@ object PlatformCompat {
   // Scala Native does not support looking up annotations at runtime.
   def isIgnoreSuite(cls: Class[_]): Boolean = false
 
-  final def isJVM: Boolean = false
-  final def isJS: Boolean = false
-  final def isNative: Boolean = true
+  final val isJVM = false
+  final val isJS = false
+  final val isNative = true
 
   def newRunner(
       taskDef: TaskDef,

--- a/tests/shared/src/main/scala/munit/PlatformCompatSuite.scala
+++ b/tests/shared/src/main/scala/munit/PlatformCompatSuite.scala
@@ -1,0 +1,14 @@
+package munit
+
+import munit.internal.PlatformCompat
+
+class PlatformCompatSuite extends FunSuite {
+
+  test("Scala.js: eliminate false branches")(
+    // the branch should be eliminated by the Scala.js linker
+    // otherwise, the compilation will fail, because TrieMap doesn't exist in Scala.js
+    if (PlatformCompat.isJVM)
+      assert(collection.concurrent.TrieMap[String, String]().isEmpty)
+  )
+
+}


### PR DESCRIPTION
This one https://github.com/scalameta/munit/pull/982 wasn't the proper way to fix the linking issue. 
I should've added the test from the very beginning. Apologies for that. 