### PR TITLE
Surface synchronous fixture-enumeration failures

### DIFF
--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -153,30 +153,38 @@ class MUnitRunner(val cls: Class[_ <: Suite], suite: Suite)
       val errors: List[Throwable],
   )
 
-  private def runBeforeAll(notifier: RunNotifier): Future[BeforeAllResult] = {
-    val result: Future[List[Try[(AnyFixture[_], Boolean)]]] = sequenceFutures(
-      munitFixtures.iterator.map(f =>
-        runHiddenTest(
-          notifier,
-          s"beforeAll(${f.fixtureName})",
-          () => f.beforeAll(),
-        ).map(isSuccess => f -> isSuccess)
+  /**
+   * Runs `beforeAll` on every suite fixture and collects the result.
+   *
+   * The body is wrapped in `Future.unit.flatMap` so that any synchronous
+   * exception thrown while forcing the `munitFixtures` lazy val becomes a
+   * `Future.failed` instead of escaping this method.
+   */
+  private def runBeforeAll(notifier: RunNotifier): Future[BeforeAllResult] =
+    Future.unit.flatMap { _ =>
+      val result: Future[List[Try[(AnyFixture[_], Boolean)]]] = sequenceFutures(
+        munitFixtures.iterator.map(f =>
+          runHiddenTest(
+            notifier,
+            s"beforeAll(${f.fixtureName})",
+            () => f.beforeAll(),
+          ).map(isSuccess => f -> isSuccess)
+        )
       )
-    )
-    result.map { results =>
-      val loadedFixtures = List.newBuilder[AnyFixture[_]]
-      val errors = List.newBuilder[Throwable]
-      var isSuccess = true
-      results.foreach {
-        case util.Failure(ex) =>
-          errors += ex
-          isSuccess = false
-        case util.Success((fixture, success)) =>
-          if (success) loadedFixtures += fixture else isSuccess = false
+      result.map { results =>
+        val loadedFixtures = List.newBuilder[AnyFixture[_]]
+        val errors = List.newBuilder[Throwable]
+        var isSuccess = true
+        results.foreach {
+          case util.Failure(ex) =>
+            errors += ex
+            isSuccess = false
+          case util.Success((fixture, success)) =>
+            if (success) loadedFixtures += fixture else isSuccess = false
+        }
+        new BeforeAllResult(isSuccess, loadedFixtures.result(), errors.result())
       }
-      new BeforeAllResult(isSuccess, loadedFixtures.result(), errors.result())
     }
-  }
 
   private def runAfterAll(
       notifier: RunNotifier,

--- a/tests/shared/src/main/scala/munit/FixtureEnumerationCrashFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/FixtureEnumerationCrashFrameworkSuite.scala
@@ -1,0 +1,14 @@
+package munit
+
+class FixtureEnumerationCrashFrameworkSuite extends munit.FunSuite {
+  override def munitFixtures: Seq[AnyFixture[_]] =
+    throw new RuntimeException("boom")
+
+  test("hello") {}
+}
+object FixtureEnumerationCrashFrameworkSuite
+    extends FrameworkTest(
+      classOf[FixtureEnumerationCrashFrameworkSuite],
+      """|==> failure munit.FixtureEnumerationCrashFrameworkSuite.unexpected error running tests - boom
+         |""".stripMargin,
+    )

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -17,6 +17,7 @@ class FrameworkSuite extends BaseFrameworkSuite {
     TagsExcludeFramweworkSuite,
     SuiteTransformCrashFrameworkSuite,
     SuiteTransformFrameworkSuite,
+    FixtureEnumerationCrashFrameworkSuite,
     TestTransformCrashFrameworkSuite,
     TestTransformFrameworkSuite,
     ValueTransformCrashFrameworkSuite,


### PR DESCRIPTION
## Summary

When a suite's `munitFixtures` throws synchronously (for example, a `require` check during fixture composition), the runner reports `Total 0` tests with no error event. The failure is silently dropped instead of surfacing as a visible test failure.

## Root cause

`runBeforeAll`'s body starts by forcing the `munitFixtures` lazy val, which calls `suite.munitFixtures`. If the user's override throws synchronously, the exception escapes `runBeforeAll` before any `Future` is constructed. The caller in `runAsync`:

```scala
runBeforeAll(notifier).transformWith { ... }.transform { res =>
  res.failed.foreach(fireFailedHiddenTest(notifier, "unexpected error running tests", _))
  notifier.fireTestSuiteFinished(description)
  ...
}
```

never gets a `Future` to chain on, so `fireFailedHiddenTest` never runs and the suite finishes with no events. The captured runner output is empty.

## Fix

Wrap `runBeforeAll`'s body in `Future.unit.flatMap`. `flatMap` catches synchronous exceptions and converts them into a failed `Future`, which then flows through the existing error-reporting path and produces a `==> failure ... unexpected error running tests` event.

## Repro / regression test

The new `FixtureEnumerationCrashFrameworkSuite` overrides `munitFixtures` to throw and asserts the failure is reported:

```scala
class FixtureEnumerationCrashFrameworkSuite extends munit.FunSuite {
  override def munitFixtures: Seq[AnyFixture[_]] =
    throw new RuntimeException("boom")

  test("hello") {}
}
```

Without the fix the captured output is empty and the assertion fails. With the fix the output is `==> failure munit.FixtureEnumerationCrashFrameworkSuite.unexpected error running tests - boom`.