### PR TITLE
Reintroduce `@EnableReflectiveInstantiation` to Scala Native test suites via `org.portable-scala:portable-scala-reflect`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ def scala3 = "3.3.7"
 def scala3next = "3.8.2"
 
 def junitVersion = "4.13.2"
+def portableScalaReflectVersion = "1.1.3"
 def gcp = "com.google.cloud" % "google-cloud-storage" % "2.64.0"
 
 inThisBuild {
@@ -152,8 +153,11 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform).settings(
   } % Provided),
 ).nativeConfigure(sharedNativeConfigure).nativeSettings(
   sharedNativeSettings,
-  libraryDependencies ++=
-    List("org.scala-native" %%% "test-interface-sbt-defs" % nativeVersion),
+  libraryDependencies ++= List(
+    "org.scala-native" %%% "test-interface-sbt-defs" % nativeVersion,
+    ("org.portable-scala" %%% "portable-scala-reflect" %
+      portableScalaReflectVersion).cross(CrossVersion.for3Use2_13) % Provided,
+  ),
 ).jsConfigure(sharedJSConfigure).jsSettings(
   sharedJSSettings,
   libraryDependencies ++= List(
@@ -161,6 +165,8 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform).settings(
       .cross(CrossVersion.for3Use2_13),
     ("org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion)
       .cross(CrossVersion.for3Use2_13),
+    ("org.portable-scala" %%% "portable-scala-reflect" %
+      portableScalaReflectVersion).cross(CrossVersion.for3Use2_13),
   ),
 ).jvmSettings(
   sharedJVMSettings,

--- a/munit/js/src/main/scala/munit/PlatformSuite.scala
+++ b/munit/js/src/main/scala/munit/PlatformSuite.scala
@@ -1,6 +1,6 @@
 package munit
 
-import scala.scalajs.reflect.annotation._
+import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
 
 // This annotation is needed to ensure that munit.Suite subclasses can be
 // reflectively classloaded.

--- a/munit/native/src/main/scala/munit/PlatformSuite.scala
+++ b/munit/native/src/main/scala/munit/PlatformSuite.scala
@@ -1,3 +1,8 @@
 package munit
 
+import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+
+// This annotation is needed to ensure that munit.Suite subclasses can be
+// reflectively classloaded.
+@EnableReflectiveInstantiation
 trait PlatformSuite


### PR DESCRIPTION
Fixes #1093