### PR TITLE
Fix links to images used by the website

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,7 +110,7 @@ Use `testOnly` to run only a single test suite in the sbt shell.
 MUnit test suites can be executed from in IntelliJ like normal test suites.
 Please ensure that the JUnit plugin is enabled.
 
-![Running MUnit from IntelliJ](https://github.com/scalameta/gh-pages-images/blob/master/munit/getting-started/oAA2ZeQ.png?raw=true)
+![Running MUnit from IntelliJ](https://github.com/scalameta/gh-pages-images/blob/main/munit/getting-started/oAA2ZeQ.png?raw=true)
 
 It's possible to run individual test cases from IntelliJ by clicking on the
 green "Play" icon in the left gutter. Alternatively, you can also use the
@@ -127,7 +127,7 @@ green "Play" icon in the left gutter. Alternatively, you can also use the
 
 MUnit test suites can be executed from VS Code like normal test suites.
 
-![Running MUnit from VS Code](https://github.com/scalameta/gh-pages-images/blob/master/munit/getting-started/hmL0hAp.png?raw=true)
+![Running MUnit from VS Code](https://github.com/scalameta/gh-pages-images/blob/main/munit/getting-started/hmL0hAp.png?raw=true)
 
 ### Search for failed tests in CI logs
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -305,12 +305,12 @@ When declaring tests in a helper function, it's useful to pass around an
 `implicit loc: munit.Location` parameter in order to show relevant source
 locations when a test fails.
 
-![Screen shot of console output with implicit Location parameter](https://github.com/scalameta/gh-pages-images/blob/master/munit/tests/v7Vv5Rk.png?raw=true)
+![Screen shot of console output with implicit Location parameter](https://github.com/scalameta/gh-pages-images/blob/main/munit/tests/v7Vv5Rk.png?raw=true)
 
 **Screenshot above**: test failure with implicit `Location` parameter, observe
 that the highlighted line points to the failing test case.
 
-![Screen shot of console output without implicit Location parameter](https://github.com/scalameta/gh-pages-images/blob/master/munit/tests/yXpA9dp.png?raw=true)
+![Screen shot of console output without implicit Location parameter](https://github.com/scalameta/gh-pages-images/blob/main/munit/tests/yXpA9dp.png?raw=true)
 
 **Screenshot above** test failure without implicit `Location` parameter, observe
 that the highlighted line points to `assertEquals` line that is reused in all

--- a/website/blog/2020-02-01-hello-world.md
+++ b/website/blog/2020-02-01-hello-world.md
@@ -119,14 +119,14 @@ learn more how to enable/disable tests with MUnit.
 The design goal for MUnit error messages is to give you as much context as
 possible to address the test failure. Let's consider a few concrete examples.
 
-![Demo showing source location for failed assertion](https://github.com/scalameta/gh-pages-images/blob/master/munit//2020-02-01-hello-world/goYdJhw.png?raw=true)
+![Demo showing source location for failed assertion](https://github.com/scalameta/gh-pages-images/blob/main/munit/2020-02-01-hello-world/goYdJhw.png?raw=true)
 
 In the image above, you can cmd+click on the
 `.../test/scala/munit/DemoSuite.scala:7` path to open the failing line of code
 in your editor. By highlighting the failing line of code, you also immediately
 gain some understanding for why the test might be failing.
 
-![Demo showing diff between values of a case class](https://github.com/scalameta/gh-pages-images/blob/master/munit//2020-02-01-hello-world/NaAU2He.png?raw=true)
+![Demo showing diff between values of a case class](https://github.com/scalameta/gh-pages-images/blob/main/munit/2020-02-01-hello-world/NaAU2He.png?raw=true)
 
 In the image above, the failing `assertEquals()` displays a diff comparing two
 values of a `User` case class. The "Obtained" section includes copy-paste
@@ -134,7 +134,7 @@ friendly syntax of the obtained value, which can be helpful in the common
 situation when a failing test case should have passed because the expected
 behavior of your program has changed.
 
-![Demo showing diff between multiline strings](https://github.com/scalameta/gh-pages-images/blob/master/munit//2020-02-01-hello-world/ZcRiR49.png?raw=true)
+![Demo showing diff between multiline strings](https://github.com/scalameta/gh-pages-images/blob/main/munit/2020-02-01-hello-world/ZcRiR49.png?raw=true)
 
 In the image above, the failing `assertNoDiff()` includes a `stripMargin`
 formatted multiline string of the obtained string. The `assertNoDiff()`
@@ -142,12 +142,12 @@ assertions is helpful for comparing multiline strings ignoring non-visible
 differences such as Windows/Unix newlines, ANSI color codes and leading/trailing
 whitespace.
 
-![Demo showing how to include clues in error messages](https://github.com/scalameta/gh-pages-images/blob/master/munit//2020-02-01-hello-world/Iy82OWe.png?raw=true)
+![Demo showing how to include clues in error messages](https://github.com/scalameta/gh-pages-images/blob/main/munit/2020-02-01-hello-world/Iy82OWe.png?raw=true)
 
 In the image above, the `clue(a)` helpers are used to enrich the error message
 with additional information that is displayed when the assertion fails.
 
-![Demo showing highlighted stack traces](https://github.com/scalameta/gh-pages-images/blob/master/munit//2020-02-01-hello-world/iosErEv.png?raw=true)
+![Demo showing highlighted stack traces](https://github.com/scalameta/gh-pages-images/blob/main/munit/2020-02-01-hello-world/iosErEv.png?raw=true)
 
 In the image above, stack trace elements that are defined from library
 dependencies like the standard library are grayed out making it easier to find
@@ -182,7 +182,7 @@ historical test data.
 The image below shows test cases in the
 [Metals codebase](https://scalameta.org/metals/docs/contributors/tests.html)
 sorted by how frequently they fail on the `master` branch.
-[![Example HTML test report based on historical data](https://github.com/scalameta/gh-pages-images/blob/master/munit//2020-02-01-hello-world/UuxYnSa.png?raw=true)](https://scalameta.org/metals/docs/contributors/tests.html)
+[![Example HTML test report based on historical data](https://github.com/scalameta/gh-pages-images/blob/main/munit/2020-02-01-hello-world/UuxYnSa.png?raw=true)](https://scalameta.org/metals/docs/contributors/tests.html)
 
 > Click on image to open full report
 


### PR DESCRIPTION
Some images on the [munit website](https://scalameta.org/munit/docs/getting-started.html) are not properly displayed
For example
<img width="1131" height="605" alt="munit_images" src="https://github.com/user-attachments/assets/97e58071-121e-4d44-ab4f-c43e8527668b" />

This PR is meant to fix that by updating the links
<img width="1651" height="605" alt="munit_images_fixed" src="https://github.com/user-attachments/assets/f53a7b98-dc37-47e5-ada5-add66cf46a70" />

