### PR TITLE
Fix spurious failure reported for empty/ignored suites

### DIFF
--- a/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
@@ -197,7 +197,9 @@ final class EventDispatcher extends RunListener {
   }
 
   private boolean recordStartTime(String label) {
-    return null == startTimes.putIfAbsent(label, System.currentTimeMillis());
+    // Suite-level descriptions have a null method name, and ConcurrentHashMap
+    // forbids null keys, so guard against it.
+    return label != null && null == startTimes.putIfAbsent(label, System.currentTimeMillis());
   }
 
   private boolean recordStartTime(Description description) {
@@ -205,7 +207,9 @@ final class EventDispatcher extends RunListener {
   }
 
   private Long elapsedTime(String label) {
-    Long startTime = startTimes.get(label);
+    // Suite-level descriptions have a null method name, and ConcurrentHashMap
+    // forbids null keys, so guard against it.
+    Long startTime = label == null ? null : startTimes.get(label);
     return startTime == null ? 0L : System.currentTimeMillis() - startTime;
   }
 

--- a/munit/js-native/src/main/scala/munit/internal/junitinterface/JUnitReporter.scala
+++ b/munit/js-native/src/main/scala/munit/internal/junitinterface/JUnitReporter.scala
@@ -106,11 +106,13 @@ final class JUnitReporter(
   def reportTestIgnored(method: String, suffix: String): Unit = {
     ignoredCount += 1
     val suffixed = if (suffix.isEmpty) "" else s" $suffix"
-    if (settings.shouldLogWarn) logEvent(Warn, method, AnsiColors.YELLOW)(
-      "==> i",
-      suffixed + " ignored",
-      nanos = System.nanoTime - suiteStartNanos,
-    )
+    // A suite-level ignore has no method name; render the suite name instead.
+    if (settings.shouldLogWarn) logEvent(
+      Warn,
+      method,
+      AnsiColors.YELLOW,
+      fq = method.isEmpty,
+    )("==> i", suffixed + " ignored", nanos = System.nanoTime - suiteStartNanos)
     emitEvent(method, Status.Ignored, None, 0)
   }
 

--- a/munit/js-native/src/main/scala/org/junit/runner/Description.scala
+++ b/munit/js-native/src/main/scala/org/junit/runner/Description.scala
@@ -10,7 +10,9 @@ class Description(
 ) {
   def addChild(description: Description): Description =
     new Description(cls, methodName, annotations, description :: children)
-  def getMethodName: String = methodName.getOrElse("<unknown>")
+  // Empty for a suite-level description (no method); the reporter renders such an
+  // event with the fully-qualified suite name instead.
+  def getMethodName: String = methodName.getOrElse("")
   def getTestClass: Option[Class[_]] = cls
   def getAnnotations: List[Annotation] = annotations
 }

--- a/tests/shared/src/main/scala/munit/EmptyFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/EmptyFrameworkSuite.scala
@@ -1,0 +1,23 @@
+package munit
+
+class EmptyFrameworkSuite extends FunSuite
+
+object EmptyFrameworkStdoutJVMSuite
+    extends FrameworkTest(
+      classOf[EmptyFrameworkSuite],
+      """|Test run munit.EmptyFrameworkSuite started
+         |==> i munit.EmptyFrameworkSuite ignored <elapsed time>
+         |Test run munit.EmptyFrameworkSuite finished: 0 failed, 1 ignored, 0 total <elapsed time>
+         |""".stripMargin,
+      tags = Set(OnlyJVM),
+      format = StdoutFormat,
+    )
+
+object EmptyFrameworkStdoutJsNativeSuite
+    extends FrameworkTest(
+      classOf[EmptyFrameworkSuite],
+      """|==> i munit.EmptyFrameworkSuite ignored
+         |""".stripMargin,
+      tags = Set(NoJVM),
+      format = StdoutFormat,
+    )

--- a/tests/shared/src/main/scala/munit/Issue497FrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/Issue497FrameworkSuite.scala
@@ -31,7 +31,8 @@ object Issue497FrameworkSuite
     extends FrameworkTest(
       classOf[Issue497FrameworkSuite],
       """|Test run munit.Issue497FrameworkSuite started
-         |Test run munit.Issue497FrameworkSuite finished: 1 failed, 1 ignored, 0 total <elapsed time>
+         |==> i munit.Issue497FrameworkSuite ignored <elapsed time>
+         |Test run munit.Issue497FrameworkSuite finished: 0 failed, 1 ignored, 0 total <elapsed time>
          |""".stripMargin,
       arguments = Array("--exclude-categories=munit.Slow"),
       tags = Set(OnlyJVM),

--- a/tests/shared/src/test/scala/munit/FrameworkSuite.scala
+++ b/tests/shared/src/test/scala/munit/FrameworkSuite.scala
@@ -2,6 +2,8 @@ package munit
 
 class FrameworkSuite extends BaseFrameworkSuite {
   val tests: List[FrameworkTest] = List[FrameworkTest](
+    EmptyFrameworkStdoutJVMSuite,
+    EmptyFrameworkStdoutJsNativeSuite,
     AfterEachExceptionSuite,
     SwallowedExceptionSuite,
     InterceptFrameworkSuite,


### PR DESCRIPTION
An empty suite (no tests, `munitIgnore`, or all tests excluded via `--exclude-categories`) was reported as `1 failed, 1 ignored, 0 total`.

MUnitRunner fires `fireTestIgnored` on the suite-level description for such suites. In EventDispatcher, building the ignored event calls `elapsedTime(description.getMethodName())`, but a suite description's method name is null, and the `startTimes` ConcurrentHashMap forbids null keys -- so `get(null)`/`putIfAbsent(null, ...)` threw an NPE that JUnit surfaced as a "Test mechanism" failure, and the ignored event itself was swallowed.

Null-guard `elapsedTime` and `recordStartTime` so an ignored suite is reported as `0 failed, 1 ignored, 0 total`.

Add EmptyFrameworkSuite covering a naturally-empty suite, and update Issue497FrameworkSuite's expected output accordingly.