### PR TITLE
ensure compilation errors are independent of terminal settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,6 +134,12 @@ val sharedSettings = List(
       case _ => Nil
     }
   },
+  Test / scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((3, minor)) => List("-pagewidth", "80")
+      case _ => Nil
+    }
+  },
 )
 
 lazy val junit = project.in(file("junit-interface")).settings(

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -257,3 +257,8 @@ Inline the `code` variable to fix the compile error.
 ```scala mdoc
 compileErrors("val x: String = 2")
 ```
+
+Note: for reproducible results on Scala3 set `-pagewidth` scalac option to a fixed value, eg 80:
+```scala
+Test / scalacOptions ++= Seq("-pagewidth", "80")  
+```

--- a/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
+++ b/munit/shared/src/main/scala-3/munit/internal/MacroCompat.scala
@@ -43,6 +43,14 @@ object MacroCompat {
   }
 
   trait CompileErrorMacro {
+
+    /**
+     * Return compilation errors as `String`.
+     *
+     * Note: for reproducible results set `-pagewidth` scalac option to a fixed value, eg 80.
+     * @param code scala code that should not compile
+     * @return formatted errors
+     */
     transparent inline def compileErrors(inline code: String): String = {
       val errors = scala.compiletime.testing.typeCheckErrors(code)
       errors.map { error =>


### PR DESCRIPTION
closes https://github.com/scalameta/munit/issues/1119
projects using `compileErrors` should add `List("-pagewidth", "80")` (or other preferred value) to scalacOptions