### PR TITLE
Drop JDK 8; build, test and release on 17 and 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         java:
-          - 8
-          - 21
+          - 17
+          - 25
         os:
           - ubuntu-latest
           - windows-latest
@@ -20,9 +20,6 @@ jobs:
           - 'testsJS'
           - 'testsNative'
           - 'plugin'
-        exclude:
-          - sbt: 'plugin'
-            java: 8
     runs-on: ${{ matrix.os }}
     env:
       GOOGLE_APPLICATION_CREDENTIALS:
@@ -58,7 +55,7 @@ jobs:
       - uses: actions/setup-java@v5.6.0
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: npm install
@@ -75,7 +72,7 @@ jobs:
       - uses: actions/setup-java@v5.6.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 17
           cache: sbt
       - name: Install LLVM
         run: sudo apt-get update && sudo apt-get install -y clang
@@ -90,7 +87,7 @@ jobs:
       - uses: actions/setup-java@v5.6.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: npm install
@@ -102,7 +99,7 @@ jobs:
       - uses: actions/setup-java@v5.6.0
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: sbt mimaReportBinaryIssues
@@ -114,7 +111,7 @@ jobs:
       - uses: actions/setup-java@v5.6.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: ./bin/scalafmt --check

--- a/.github/workflows/release-website.yml
+++ b/.github/workflows/release-website.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-java@v5.6.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: git fetch --unshallow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-java@v5.6.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: git fetch --unshallow

--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ val sharedSettings = List(
   javacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((3, minor)) if minor >= 8 => Seq("--release", "17")
-      case _ => Seq("-source", "1.8", "-target", "1.8")
+      case _ => Seq("--release", "8")
     }
   },
   scalacOptions ++= {
@@ -125,7 +125,7 @@ val sharedSettings = List(
         )
       case Some((2, _)) => List(
           "-Yrangepos",
-          "-target:jvm-1.8",
+          "-release:8",
           // -Xlint is unusable because of
           // https://github.com/scala/bug/issues/10448
           "-Ywarn-unused:imports",
@@ -158,8 +158,7 @@ lazy val junit = project.in(file("junit-interface")).settings(
     "junit" % "junit" % junitVersion,
     "org.scala-sbt" % "test-interface" % "1.0",
   ),
-  Compile / javacOptions ++= List("-target", "1.8", "-source", "1.8"),
-  Compile / doc / javacOptions --= List("-target", "1.8"),
+  Compile / javacOptions ++= List("--release", "8"),
 )
 
 lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform).settings(


### PR DESCRIPTION
Scala 3.8 and sbt 2 need 17+, js and native prefer it, so 17 becomes the floor and 25 its eventual successor; releases move off 21, which is no longer tested. Output stays on Java 8, now via --release.