### PR TITLE
CI: cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Runs ask for 19 workers and spend 83% of their wall clock queued, so superseded runs are costly: four pushes to main 12s apart once tied up 76 workers. Note this also cancels an in-flight run on main.