### PR TITLE
Select the jsdom jsEnv via MUNIT_JS_ENV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
       - run: npm install
       - run: sbt +testsJS/test
         env:
+          MUNIT_JS_ENV: jsdom
           GOOGLE_APPLICATION_CREDENTIALS:
             ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_APPLICATION_CREDENTIALS_JSON:

--- a/build.sbt
+++ b/build.sbt
@@ -248,7 +248,7 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     scalaJSUseMainModuleInitializer := true,
     jsEnv := {
       val log = sLog.value
-      if (Option(System.getenv("GITHUB_JOB")).contains("jsdom")) {
+      if (Option(System.getenv("MUNIT_JS_ENV")).contains("jsdom")) {
         log.info("Testing in JSDOMNodeJSEnv")
         new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
       } else {


### PR DESCRIPTION
GITHUB_JOB tied the jsenv to a CI job id, so the jsdom leg could only live in a job named `jsdom`. A dedicated variable lets it share a worker with other work.