### PR TITLE
Revive the Java formatter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,8 @@ inThisBuild {
     )),
     scalaVersion := scala213,
     useSuperShell := false,
+    // the bundled google-java-format needs 21; pick one our floor JDK can run
+    javafmtFormatterCompatibleJavaVersion := 17,
   )
 }
 
@@ -67,7 +69,7 @@ addCommandAlias(
 )
 addCommandAlias(
   "preparePR",
-  "; scalafmtSbt; reload; +scalafmt; +Test/scalafmt ; scalafixCheckAll",
+  "; scalafmtSbt; reload; +scalafmt; +Test/scalafmt ; javafmt ; scalafixCheckAll",
 )
 val isPreScala213 = Set[Option[(Long, Long)]](Some((2, 11)), Some((2, 12)))
 val scala2Versions = List(scala213, scala212)

--- a/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/EventDispatcher.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
@@ -247,7 +246,8 @@ final class EventDispatcher extends RunListener {
   }
 
   void testExecutionFailed(String testName, Throwable err) {
-    post(RunSettings.LogMode.ERROR,
+    post(
+        RunSettings.LogMode.ERROR,
         new Event(
             Ansi.c(testName, Ansi.ERRMSG), settings.buildErrorMessage(err), Status.Error, 0L, err) {
           void logTo(RichLogger logger) {

--- a/junit-interface/src/main/java/munit/internal/junitinterface/JUnitRunner.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/JUnitRunner.java
@@ -5,11 +5,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.junit.runner.notification.RunListener;
 import sbt.testing.Runner;
 import sbt.testing.Selector;
@@ -179,8 +177,7 @@ final class JUnitRunner implements Runner {
         default:
       }
     }
-    if (logMode == null)
-      logMode = verbose ? RunSettings.LogMode.TRACE : RunSettings.LogMode.INFO;
+    if (logMode == null) logMode = verbose ? RunSettings.LogMode.TRACE : RunSettings.LogMode.INFO;
     this.settings =
         new RunSettings(
             !nocolor,

--- a/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
+++ b/junit-interface/src/main/java/munit/internal/junitinterface/RunSettings.java
@@ -2,7 +2,6 @@ package munit.internal.junitinterface;
 
 import java.lang.reflect.Method;
 import java.util.*;
-
 import org.junit.runner.Description;
 import sbt.testing.Status;
 
@@ -269,7 +268,6 @@ class RunSettings implements Settings {
           throw new IllegalArgumentException(sb.toString());
       }
     }
-
   }
 
   static enum Summary {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,6 +15,6 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
-addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.8.0")
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.13.1")
 
 libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.71.0"


### PR DESCRIPTION
com.lightbend.sbt stopped at 0.8.0, so scala-steward saw no updates for it; move to com.github.sbt 0.13.1, cap its formatter at our floor JDK, and reformat the three files that had drifted unnoticed.