### PR TITLE
Pin sbt to 1.x for scala-steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,10 @@
+# sbt 2 requires every plugin republished as _sbt2_3, and two we cannot do
+# without have no such build yet -- crossProject is the shape of this build,
+# and jsdom is a test environment we rely on:
+#   org.portable-scala:sbt-{,scalajs-,scala-native-}crossproject
+#     ported in portable-scala/sbt-crossproject#178, unmerged
+#   org.scala-js:scalajs-env-jsdom-nodejs  (needs a _3 build; none published)
+# Keep taking 1.x updates; drop the pin once both publish for sbt 2.
+updates.pin = [
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = { prefix = "1." } }
+]


### PR DESCRIPTION
sbt 2 needs every plugin republished as _sbt2_3, and portable-scala's crossproject plugins and scalajs-env-jsdom-nodejs have no such build. The crossproject port exists but is unmerged; unpin once it ships.

Closes #1137.