### PR TITLE
sbt2: switch from 1.12.14 to 2.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: sbt checkDiscoveryNative
       - &testplugin
         if: ${{ !cancelled() }}
-        run: sbt +plugin/test
+        run: sbt +plugin/testFull
       - if: ${{ !cancelled() }}
         run: sbt scalafixCheckAll
       - if: ${{ !cancelled() }}

--- a/build.sbt
+++ b/build.sbt
@@ -56,11 +56,11 @@ def scalafixOn(args: String) = onEach(scalafixTargets, s"scalafix $args") +
   onEach(scalafixTargets, s"Test/scalafix $args")
 addCommandAlias("scalafixAll", "; scalafixEnable" + scalafixOn(""))
 addCommandAlias("scalafixCheckAll", "; scalafixEnable" + scalafixOn("--check"))
-addCommandAlias("testJVM", onEach(tests.jvm.get, "test"))
-addCommandAlias("testJS", onEach(allScalaVersions.map(tests.js(_)), "test"))
+addCommandAlias("testJVM", onEach(tests.jvm.get, "testFull"))
+addCommandAlias("testJS", onEach(allScalaVersions.map(tests.js(_)), "testFull"))
 addCommandAlias(
   "testNative",
-  onEach(allScalaVersions.map(tests.native(_)), "test"),
+  onEach(allScalaVersions.map(tests.native(_)), "testFull"),
 )
 addCommandAlias("checkDiscoveryNative", onEach(tests.native.get, "run"))
 addCommandAlias("checkDiscoveryJS", onEach(tests.js.get, "run"))
@@ -83,8 +83,8 @@ def isScala3(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 3)
 val unpublished = publish / skip := true
 
 // NOTE(olafur): disable Scala.js and Native settings for IntelliJ.
-val skipIdeaSetting =
-  SettingKey[Boolean]("ide-skip-project", rank = KeyRanks.Invisible)
+val skipIdeaSetting = SettingKey[Boolean]("ide-skip-project")
+  .withRank(KeyRanks.Invisible)
 def onOtherPlatform(except: AutoPlugin*): Project => Project =
   _.disablePlugins(MimaPlugin +: except: _*).settings(skipIdeaSetting := true)
 val onJS: Project => Project = onOtherPlatform()
@@ -170,7 +170,7 @@ val munitSettings = Def.settings(
   unmanagedMainSources("munit", "shared"),
   libraryDependencies ++= List(
     scalaReflect.value,
-    ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.3")
+    ("org.portable-scala" %% "portable-scala-reflect" % "1.1.3")
       .cross(CrossVersion.for3Use2_13),
   ),
 )
@@ -184,7 +184,7 @@ val munitOnJVM: Project => Project = _.dependsOn(junit).settings(
 val munitOnNative: Project => Project = onNative.settings(
   unmanagedMainSources("munit", "native", "js-native"),
   libraryDependencies ++=
-    List("org.scala-native" %%% "test-interface-sbt-defs" % nativeVersion),
+    List("org.scala-native" %% "test-interface-sbt-defs" % nativeVersion),
 )
 
 val munitOnJS: Project => Project = onJS.settings(
@@ -264,7 +264,7 @@ val testsOnJS: Project => Project = onJS.settings(
   unmanagedSources("tests", "js"),
   Compile / mainClass := Some("munit.ReflectiveInstantiationCheck"),
   scalaJSUseMainModuleInitializer := true,
-  jsEnv := {
+  jsEnv := Def.uncached {
     val log = sLog.value
     if (System.getenv("MUNIT_JS_ENV") == "jsdom") {
       log.info("Testing in JSDOMNodeJSEnv")
@@ -282,7 +282,8 @@ lazy val tests = projectMatrix.in(file("tests")).dependsOn(munit)
   .nativePlatform(List(scala3next), nextRow, testsOnNative)
   .jsPlatform(allScalaVersions, Nil, testsOnJS)
   .jsPlatform(List(scala3next), nextRow, testsOnJS)
-  .jvmPlatform(allScalaVersions, testsJVMSettings).disablePlugins(MimaPlugin)
+  .jvmPlatform(allScalaVersions, Nil, _.settings(testsJVMSettings))
+  .disablePlugins(MimaPlugin)
 
 // A matrix cell per Scala version replaces `+`, so the platform-wide commands
 // are aliases over the cells rather than one cross-built project.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.15
+sbt.version=2.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,11 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
-libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.1"
+libraryDependencies += ("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.1")
+  .cross(CrossVersion.for3Use2_13)
+  .exclude("org.scala-js", "scalajs-env-nodejs_2.13")
+  .exclude("org.scala-js", "scalajs-js-envs_2.13")
+  .exclude("org.scala-js", "scalajs-logging_2.13")
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
 
@@ -16,5 +20,3 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
 addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.13.1")
 
 libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.71.0"
-
-addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")


### PR DESCRIPTION
- sbt 2 contains projectMatrix, so we don't need the plugin anymore
- `test` is aliased to `testQuick`, so the aliases and CI run `testFull`
- `%%` now carries the platform suffix as well, thus superseding `%%%`.

Co-Authored-By: Claude <noreply@anthropic.com>
