### PR TITLE
MUnitRunner: run test body in a Future

### DIFF
--- a/munit/shared/src/main/scala/munit/FunSuite.scala
+++ b/munit/shared/src/main/scala/munit/FunSuite.scala
@@ -34,7 +34,7 @@ trait BaseFunSuite
         try waitForCompletion(() => munitValueTransform(body))
         catch { case NonFatal(e) => Future.failed(e) }
       },
-      options.tags.toSet,
+      options.tags,
       loc,
     ))
 

--- a/munit/shared/src/main/scala/munit/MUnitRunner.scala
+++ b/munit/shared/src/main/scala/munit/MUnitRunner.scala
@@ -277,11 +277,6 @@ class MUnitRunner(val cls: Class[_ <: Suite], suite: Suite)
     catch { case ex: Throwable => onResult(util.Failure(ex)) }
   }
 
-  private def futureFromAny(any: Any): Future[Any] = any match {
-    case f: Future[_] => f
-    case _ => Future.successful(any)
-  }
-
   private def runTestBody(
       notifier: RunNotifier,
       description: Description,
@@ -377,10 +372,14 @@ class MUnitRunner(val cls: Class[_ <: Suite], suite: Suite)
 
   private def valueTransform(thunk: () => Any): Future[Any] = suite match {
     case funSuite: FunSuite => funSuite.munitValueTransform(thunk())
-    case _ => futureFromAny(thunk())
+    case _ => Future(thunk()).flatMap {
+        case f: Future[_] => f
+        case other => Future.successful(other)
+      }
   }
 
 }
+
 object MUnitRunner {
   private def ensureEligibleConstructor(
       cls: Class[_ <: Suite]

--- a/munit/shared/src/main/scala/munit/ValueTransforms.scala
+++ b/munit/shared/src/main/scala/munit/ValueTransforms.scala
@@ -2,8 +2,7 @@ package munit
 
 import munit.internal.console.StackTraces
 
-import scala.concurrent.Future
-import scala.util.Try
+import scala.concurrent._
 
 trait ValueTransforms {
   this: BaseFunSuite =>
@@ -18,6 +17,7 @@ trait ValueTransforms {
   def munitValueTransforms: List[ValueTransform] = List(munitFutureTransform)
 
   final def munitValueTransform(testValue: => Any): Future[Any] = {
+    implicit val ec: ExecutionContext = munitExecutionContext
     // Takes an arbitrarily nested future `Future[Future[Future[...]]]` and
     // returns a `Future[T]` where `T` is not a `Future`.
     def flattenFuture(future: Future[_]): Future[_] = future.map { value =>
@@ -27,9 +27,8 @@ trait ValueTransforms {
         case Some(f) => flattenFuture(f)
         case None => Future.successful(value)
       }
-    }(munitExecutionContext).flatten
-    val wrappedFuture = Future.fromTry(Try(StackTraces.dropOutside(testValue)))
-    flattenFuture(wrappedFuture)
+    }.flatten
+    flattenFuture(Future(StackTraces.dropOutside(testValue)))
   }
 
   final def munitFutureTransform: ValueTransform =


### PR DESCRIPTION
Even if it returns a Future, the majority of its body might be an expensive, exception-throwing setup.