### PR TITLE
Take the mima baseline from the last tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - &checkout
         uses: actions/checkout@v7
+        with:
+          # the mima baseline is the last tag
+          fetch-depth: 0
       - &jdk
         uses: actions/setup-java@v5.6.0
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@ import scala.collection.mutable
 
 import Extensions._
 
-def previousVersion = "1.0.0-RC1"
-
 def scala213 = "2.13.18"
 
 def scala212 = "2.12.21"
@@ -93,10 +91,11 @@ val onNative: Project => Project = onOtherPlatform(ScalafixPlugin)
 val mimaEnable = Def.settings(
   mimaBinaryIssueFilters +=
     _root_.munit.build.Mima.languageAgnosticCompatibilityPolicy,
-  mimaPreviousArtifacts := Set(
-    if (crossPaths.value) "org.scalameta" %% moduleName.value % previousVersion
-    else "org.scalameta" % moduleName.value % previousVersion
-  ),
+  // the last tag, so the baseline cannot go stale; CI has to fetch tags for it
+  mimaPreviousArtifacts := previousStableVersion.value.map(v =>
+    if (crossPaths.value) "org.scalameta" %% moduleName.value % v
+    else "org.scalameta" % moduleName.value % v
+  ).toSet,
 )
 
 // The matrix supplies the Scala versions, so crossScalaVersions is gone; what


### PR DESCRIPTION
previousVersion was pinned at 1.0.0-RC1, so nothing added since then was protected. previousStableVersion follows the tags, and the shared checkout now fetches them — without that it would be None and the check would pass vacuously.