### PR TITLE
Mima: treat a top-level class as accessible

### DIFF
--- a/project/MunitMimaUtils.scala
+++ b/project/MunitMimaUtils.scala
@@ -5,8 +5,10 @@ object MunitMimaUtils {
   def isPublic(obj: MemberInfo): Boolean =
     (null ne obj) && !obj.nonAccessible && isPublic(obj.owner)
 
+  // `outer` is NoClass for a top-level class, and NoClass carries no flags, so
+  // it must count as public or every top-level class is deemed inaccessible.
   def isPublic(obj: ClassInfo, ref: AnyRef = null): Boolean = (obj eq ref) ||
-    (null ne obj) && obj.scopedPrivateSuff.isEmpty &&
+    (obj eq NoClass) || (null ne obj) && obj.scopedPrivateSuff.isEmpty &&
     obj.isPublic && isPublic(obj.module, obj) && isPublic(obj.outer, obj)
 
 }


### PR DESCRIPTION
`ClassInfo.outer` is NoClass for a top-level class, not null, and NoClass carries no access flags, so the recursion deemed every top-level class inaccessible and the policy filtered every problem mima found.