### PR TITLE
fix: handle null exception message in munitAppendToFailureMessage

### DIFF
--- a/munit/shared/src/main/scala/munit/TestTransforms.scala
+++ b/munit/shared/src/main/scala/munit/TestTransforms.scala
@@ -71,7 +71,8 @@ trait TestTransforms {
               Failure(Exceptions.rootCause(exception) match {
                 case fel: FailExceptionLike[_] => fel.updateMessage(append)
                 case e => new FailException(
-                    message = append(e.getMessage),
+                    message =
+                      append(Option(e.getMessage).getOrElse(e.getClass.getName)),
                     cause = e,
                     isStackTracesEnabled = false,
                     location = t.location,

--- a/tests/shared/src/main/scala/munit/TestTransformFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/TestTransformFrameworkSuite.scala
@@ -17,6 +17,7 @@ class TestTransformFrameworkSuite extends munit.FunSuite {
   test("suffix-success") {}
   test("suffix-fail")(fail("boom"))
   test("suffix-assertEquals")(assertEquals(0, 1))
+  test("suffix-null-message")(throw new NullPointerException())
 }
 object TestTransformFrameworkSuite
     extends FrameworkTest(
@@ -31,13 +32,15 @@ object TestTransformFrameworkSuite
          |==> failure munit.TestTransformFrameworkSuite.suffix-assertEquals - tests/shared/src/main/scala/munit/TestTransformFrameworkSuite.scala:19
          |18:  test("suffix-fail")(fail("boom"))
          |19:  test("suffix-assertEquals")(assertEquals(0, 1))
-         |20:}
+         |20:  test("suffix-null-message")(throw new NullPointerException())
          |values are not the same
          |=> Obtained
          |0
          |=> Diff (- expected, + obtained)
          |-1
          |+0
+         |==> extra info
+         |==> failure munit.TestTransformFrameworkSuite.suffix-null-message - java.lang.NullPointerException
          |==> extra info
          |""".stripMargin,
     )


### PR DESCRIPTION
## Summary

- Guard `munitAppendToFailureMessage` against throwables whose `getMessage` is `null` by falling back to the exception class name before calling `append`.
- Add a framework test (`suffix-null-message`) that throws a message-less `NullPointerException` with a failure suffix transform applied.

Fixes #1090

## Test plan

- [x] Reproduced pre-fix NPE: `Cannot invoke "String.endsWith(String)" because "existing" is null` when `suffix-null-message` runs without the guard
- [x] `sbt preparePR` (scalafmt, javafmt, scalafixCheckAll)
- [x] `sbt "tests2_13/testOnly munit.FrameworkSuite"` — 39 passed, 0 failed